### PR TITLE
Use runtime env var for `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES`

### DIFF
--- a/cosmos_xenna/ray_utils/cluster.py
+++ b/cosmos_xenna/ray_utils/cluster.py
@@ -69,8 +69,7 @@ def init_or_connect_to_cluster(
 
     # We need to set this env var to avoid ray from setting CUDA_VISIBLE_DEVICES.
     # We set these manually in Xenna because we allocate the gpus manually instead of relying on ray's mechanisms.
-    # This will *only* get picked up from here if the cluster is started from this script. In the case of previously
-    # existing clusters, this needs to be set in the processes that set up the cluster.
+    # Set for the current process (needed for cluster initialization)
     os.environ["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = "0"
     # These need to be set to allow listing debug info about more than 10k actors.
     os.environ["RAY_MAX_LIMIT_FROM_API_SERVER"] = str(API_LIMIT)
@@ -88,6 +87,8 @@ def init_or_connect_to_cluster(
         ignore_reinit_error=True,
         log_to_driver=log_to_driver,
         _metrics_export_port=ray_metrics_port,
+        # Ensure Ray workers also have the environment variable set (works for both new and existing clusters)
+        runtime_env={"env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "0"}}
     )
     logger.info(f"Ray dashboard url: {context.dashboard_url}")
     return context


### PR DESCRIPTION
Currently its needed that an existing ray cluster is started with the following env varibale 
`RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0`

However if a user starts a ray cluster without this env variable, then the gpu allocation doesn't work out and error out here https://github.com/nvidia-cosmos/cosmos-xenna/blob/c62aa91db62d14dcbf20cba69cfe3247b95016a9/cosmos_xenna/ray_utils/stage_worker.py#L376-L381

I believe this PR should allow us to attach to existing cluster where that envvar wasn't set.


## Earlier
```python
RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 ray start --num-cpus 16 --num-gpus 4 --port 1234

RAY_ADDRESS=localhost:1234 python main.py
```

## Now
```python
ay start --num-cpus 16 --num-gpus 4 --port 1234

RAY_ADDRESS=localhost:1234 python main.py
```

## TODO haven't tested really for edge cases