### PR TITLE
Log after ray cluster is initialized

### DIFF
--- a/cosmos_xenna/pipelines/private/pipelines.py
+++ b/cosmos_xenna/pipelines/private/pipelines.py
@@ -139,7 +139,6 @@ def run_pipeline(
     if pipeline_spec.config.monitoring_verbosity_level >= VerbosityLevel.INFO:
         logger.info(pipeline_spec)
 
-    logger.info("Initialized Ray cluster.")
     cluster.init_or_connect_to_cluster()
 
     cluster_resources = cluster.make_cluster_resources_from_ray_nodes(

--- a/cosmos_xenna/ray_utils/cluster.py
+++ b/cosmos_xenna/ray_utils/cluster.py
@@ -89,5 +89,6 @@ def init_or_connect_to_cluster(
         log_to_driver=log_to_driver,
         _metrics_export_port=ray_metrics_port,
     )
+    logger.info("Initialized Ray cluster.")
     logger.info(f"Ray dashboard url: {context.dashboard_url}")
     return context


### PR DESCRIPTION
I think it would be better if logging is done after ray cluster is actually initialized, because initializing ray cluster could fail unexpectedly.