### PR TITLE
Add GitHub Actions pipeline for tests and lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  IS_RUNNING_IN_CICD: "1"
 
 jobs:
   # -------------------------------------------------------------------
@@ -36,8 +37,6 @@ jobs:
     name: Python Lint
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
-    env:
-      IS_RUNNING_IN_CICD: "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -70,8 +69,6 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-22.04, ubuntu-22.04-arm]
-    env:
-      IS_RUNNING_IN_CICD: "1"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Setup Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
-          cache-workspaces: ". -> target"
+          workspaces: ". -> target"
 
       - uses: astral-sh/setup-uv@v4
         with:
@@ -72,9 +75,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Setup Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
-          cache-workspaces: ". -> target"
+          workspaces: ". -> target"
 
       - uses: astral-sh/setup-uv@v4
         with:
@@ -99,9 +105,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Setup Rust toolchain
+        run: |
+          rustup show active-toolchain || rustup toolchain install stable --profile minimal
+          rustup component add clippy rustfmt
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
-          components: clippy, rustfmt
+          workspaces: ". -> target"
 
       - name: cargo fmt
         run: cargo fmt --check
@@ -125,7 +136,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Setup Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          workspaces: ". -> target"
 
       - name: cargo test
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # -------------------------------------------------------------------
+  # Python lint — platform-independent, so only runs on x86_64.
+  # Runs on PRs only.
+  # -------------------------------------------------------------------
+  python-lint:
+    name: Python Lint
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    env:
+      IS_RUNNING_IN_CICD: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-workspaces: ". -> target"
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies and build extension
+        run: |
+          uv sync
+          uv run maturin develop --release
+
+      - name: Lint (ruff, pyright, license headers)
+        run: uv run run_presubmit.py lint --no-fix
+
+  # -------------------------------------------------------------------
+  # Python tests — on both x86_64 and arm64.
+  # -------------------------------------------------------------------
+  python-test:
+    name: Python Tests (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-22.04, ubuntu-22.04-arm]
+    env:
+      IS_RUNNING_IN_CICD: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-workspaces: ". -> target"
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies and build extension
+        run: |
+          uv sync
+          uv run maturin develop --release
+
+      - name: Unit tests
+        run: uv run run_presubmit.py unit-test
+
+  # -------------------------------------------------------------------
+  # Rust lint — platform-independent, so only runs on x86_64.
+  # Runs on PRs only.
+  # -------------------------------------------------------------------
+  rust-lint:
+    name: Rust Lint
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
+
+      - name: cargo fmt
+        run: cargo fmt --check
+
+      - name: cargo check
+        run: cargo check --all-targets
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+  # -------------------------------------------------------------------
+  # Rust tests — on both x86_64 and arm64.
+  # -------------------------------------------------------------------
+  rust-test:
+    name: Rust Tests (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-22.04, ubuntu-22.04-arm]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: cargo test
+        run: cargo test
+
+      - name: cargo test (release)
+        run: cargo test --release --features release-tests
+
+  # -------------------------------------------------------------------
+  # Gate job: single required status check for branch protection rules.
+  #
+  # On PRs: all four jobs must succeed.
+  # On push to main: lint jobs are skipped; only tests must succeed.
+  # -------------------------------------------------------------------
+  ci-pass:
+    name: CI Pass
+    if: always()
+    needs: [python-lint, python-test, rust-lint, rust-test]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Verify all jobs passed
+        run: |
+          results=("${{ needs.python-lint.result }}" \
+                   "${{ needs.python-test.result }}" \
+                   "${{ needs.rust-lint.result }}" \
+                   "${{ needs.rust-test.result }}")
+          for r in "${results[@]}"; do
+            # "skipped" is acceptable — lint jobs are intentionally skipped on push to main.
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              echo "::error::One or more CI jobs did not succeed (got: $r)"
+              exit 1
+            fi
+          done

--- a/cosmos_xenna/pipelines/v1/test_actor_pool_heavy.py
+++ b/cosmos_xenna/pipelines/v1/test_actor_pool_heavy.py
@@ -25,6 +25,7 @@ from typing import Optional
 import pytest
 
 from cosmos_xenna.pipelines import v1 as pipelines_v1
+from cosmos_xenna.utils.ci import is_running_in_cicd
 
 
 class SimpleStage(pipelines_v1.Stage):
@@ -37,7 +38,9 @@ class SimpleStage(pipelines_v1.Stage):
 
     @property
     def required_resources(self) -> pipelines_v1.Resources:
-        return pipelines_v1.Resources(cpus=3.0, gpus=0.0)
+        # Scale per-stage CPU requirements for CI jobs.
+        cpus = 1.5 if is_running_in_cicd() else 3.0
+        return pipelines_v1.Resources(cpus=cpus, gpus=0.0)
 
     def setup(self, worker_metadata: pipelines_v1.WorkerMetadata) -> None:
         print("setup")

--- a/cosmos_xenna/pipelines/v1/test_allocating_with_limited_tasks.py
+++ b/cosmos_xenna/pipelines/v1/test_allocating_with_limited_tasks.py
@@ -32,6 +32,7 @@ import pytest
 
 import cosmos_xenna.pipelines.v1 as pipelines_v1
 from cosmos_xenna.pipelines.private import resources
+from cosmos_xenna.utils.ci import is_running_in_cicd
 
 
 class _ProcessStage(pipelines_v1.Stage):
@@ -45,7 +46,9 @@ class _ProcessStage(pipelines_v1.Stage):
 
     @property
     def required_resources(self) -> pipelines_v1.Resources:
-        return pipelines_v1.Resources(cpus=0.5, gpus=0.0)
+        # Scale per-stage CPU requirements for CI jobs (10 workers per node => 2.5 total).
+        cpus = 0.25 if is_running_in_cicd() else 0.5
+        return pipelines_v1.Resources(cpus=cpus, gpus=0.0)
 
     def setup(self, worker_metadata: resources.WorkerMetadata) -> None:
         time.sleep(self._setup_dur)

--- a/cosmos_xenna/pipelines/v1/test_autoscaling.py
+++ b/cosmos_xenna/pipelines/v1/test_autoscaling.py
@@ -26,6 +26,7 @@ import pytest
 
 import cosmos_xenna.pipelines.v1 as pipelines_v1
 from cosmos_xenna.pipelines.private import resources
+from cosmos_xenna.utils.ci import is_running_in_cicd
 
 
 class _ProcessStage(pipelines_v1.Stage):
@@ -39,7 +40,9 @@ class _ProcessStage(pipelines_v1.Stage):
 
     @property
     def required_resources(self) -> pipelines_v1.Resources:
-        return pipelines_v1.Resources(cpus=1.0, gpus=0.0)
+        # Scale per-stage CPU requirements for CI jobs (5 stages => 2.5 total).
+        cpus = 0.5 if is_running_in_cicd() else 1.0
+        return pipelines_v1.Resources(cpus=cpus, gpus=0.0)
 
     def setup(self, worker_metadata: resources.WorkerMetadata) -> None:
         time.sleep(self._setup_dur)

--- a/cosmos_xenna/pipelines/v1/test_batch_size_hang.py
+++ b/cosmos_xenna/pipelines/v1/test_batch_size_hang.py
@@ -21,6 +21,7 @@ import pytest  # noqa: F401
 
 from cosmos_xenna.pipelines import v1 as pipelines_v1
 from cosmos_xenna.utils import python_log as logger
+from cosmos_xenna.utils.ci import is_running_in_cicd
 
 
 @attrs.define
@@ -67,7 +68,9 @@ class SimpleStage(pipelines_v1.Stage):
 
     @property
     def required_resources(self) -> pipelines_v1.Resources:
-        return pipelines_v1.Resources(cpus=5.0, gpus=0.0)
+        # Scale per-stage CPU requirements for CI jobs.
+        cpus = 1.0 if is_running_in_cicd() else 5.0
+        return pipelines_v1.Resources(cpus=cpus, gpus=0.0)
 
     def process_data(self, samples: list[_Sample]) -> list[_Sample]:
         return samples

--- a/cosmos_xenna/pipelines/v1/test_batching.py
+++ b/cosmos_xenna/pipelines/v1/test_batching.py
@@ -17,6 +17,7 @@
 import pytest  # noqa: F401
 
 from cosmos_xenna.pipelines import v1 as pipelines_v1
+from cosmos_xenna.utils.ci import is_running_in_cicd
 
 
 class Stage(pipelines_v1.Stage):
@@ -29,7 +30,9 @@ class Stage(pipelines_v1.Stage):
 
     @property
     def required_resources(self) -> pipelines_v1.Resources:
-        return pipelines_v1.Resources(cpus=2.0, gpus=0.0)
+        # Scale per-stage CPU requirements for CI jobs.
+        cpus = 1.0 if is_running_in_cicd() else 2.0
+        return pipelines_v1.Resources(cpus=cpus, gpus=0.0)
 
     def process_data(self, in_data: list[int]) -> list[int]:
         assert len(in_data) == self._batch_size

--- a/cosmos_xenna/pipelines/v1/test_empty_return.py
+++ b/cosmos_xenna/pipelines/v1/test_empty_return.py
@@ -19,6 +19,7 @@ import time
 import pytest  # noqa: F401
 
 from cosmos_xenna.pipelines import v1 as pipelines_v1
+from cosmos_xenna.utils.ci import is_running_in_cicd
 
 
 class SimpleStage(pipelines_v1.Stage):
@@ -31,7 +32,9 @@ class SimpleStage(pipelines_v1.Stage):
 
     @property
     def required_resources(self) -> pipelines_v1.Resources:
-        return pipelines_v1.Resources(cpus=3.0, gpus=0.0)
+        # Scale per-stage CPU requirements for CI jobs.
+        cpus = 1.5 if is_running_in_cicd() else 3.0
+        return pipelines_v1.Resources(cpus=cpus, gpus=0.0)
 
     def setup(self, worker_metadata: pipelines_v1.WorkerMetadata) -> None:
         print("setup")

--- a/cosmos_xenna/pipelines/v1/test_setup_on_node.py
+++ b/cosmos_xenna/pipelines/v1/test_setup_on_node.py
@@ -19,6 +19,7 @@ import time
 import pytest  # noqa: F401
 
 from cosmos_xenna.pipelines import v1 as pipelines_v1
+from cosmos_xenna.utils.ci import is_running_in_cicd
 
 
 class Stage(pipelines_v1.Stage):
@@ -31,7 +32,9 @@ class Stage(pipelines_v1.Stage):
 
     @property
     def required_resources(self) -> pipelines_v1.Resources:
-        return pipelines_v1.Resources(cpus=2.0, gpus=0.0)
+        # Scale per-stage CPU requirements for CI jobs.
+        cpus = 1.0 if is_running_in_cicd() else 2.0
+        return pipelines_v1.Resources(cpus=cpus, gpus=0.0)
 
     def setup_on_node(self, node_info: pipelines_v1.NodeInfo, worker_metadata: pipelines_v1.WorkerMetadata) -> None:
         self._setup_on_node_result = True

--- a/cosmos_xenna/pipelines/v1/test_slots_resizing.py
+++ b/cosmos_xenna/pipelines/v1/test_slots_resizing.py
@@ -19,6 +19,7 @@ import time
 import pytest
 
 from cosmos_xenna.pipelines import v1 as pipelines_v1
+from cosmos_xenna.utils.ci import is_running_in_cicd
 
 
 class _ProcessStage(pipelines_v1.Stage):
@@ -28,7 +29,10 @@ class _ProcessStage(pipelines_v1.Stage):
 
     @property
     def required_resources(self) -> pipelines_v1.Resources:
-        return pipelines_v1.Resources(cpus=0.5, gpus=0.0)
+        # Scale per-stage CPU requirements for CI jobs
+        # (1 + 10 workers per node => 0.25 + 2.5 = 2.75 total).
+        cpus = 0.25 if is_running_in_cicd() else 0.5
+        return pipelines_v1.Resources(cpus=cpus, gpus=0.0)
 
     @property
     def stage_batch_size(self) -> int:

--- a/cosmos_xenna/utils/ci.py
+++ b/cosmos_xenna/utils/ci.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for detecting whether code is running in CI.
+
+The CI workflow sets ``IS_RUNNING_IN_CICD=1`` on jobs that execute tests. Tests
+can use :func:`is_running_in_cicd` to scale down resource requirements so they
+fit on small hosted runners while keeping more realistic values when run
+locally by developers.
+"""
+
+import os
+
+
+def is_running_in_cicd() -> bool:
+    """Return ``True`` if the ``IS_RUNNING_IN_CICD`` env var is set to a truthy value."""
+    return os.environ.get("IS_RUNNING_IN_CICD", "").strip() not in ("", "0", "false", "False")

--- a/src/file_distribution/common.rs
+++ b/src/file_distribution/common.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use pyo3::prelude::*;
 use std::path::PathBuf;
 use uuid::Uuid;

--- a/src/file_distribution/data_plane.rs
+++ b/src/file_distribution/data_plane.rs
@@ -248,7 +248,9 @@ fn find_cached_things_and_remove_invalid(
 
     let objects_no_unpacking: HashSet<Uuid> = cached_objects
         .iter()
-        .filter(|id| !objects_already_unpacked.contains(id) && !objects_needed_to_be_unpacked.contains(id))
+        .filter(|id| {
+            !objects_already_unpacked.contains(id) && !objects_needed_to_be_unpacked.contains(id)
+        })
         .copied()
         .collect();
 

--- a/src/file_distribution/data_plane.rs
+++ b/src/file_distribution/data_plane.rs
@@ -701,12 +701,12 @@ impl DataPlane {
         }
     }
 
-    pub fn start_p2p_server(&mut self, port: Option<u16>) -> u16 {
+    pub fn start_p2p_server(&mut self, port: Option<u16>) -> Result<u16, P2pServerError> {
         let port = port
             .or_else(|| Some(portpicker::pick_unused_port().unwrap()))
             .unwrap();
-        self.p2p_server = Some(P2pServer::new(port, self.node_id.clone(), self.is_test));
-        port
+        self.p2p_server = Some(P2pServer::new(port, self.node_id.clone(), self.is_test)?);
+        Ok(port)
     }
 
     pub fn start(&mut self) -> Result<(), OrchestratorError> {

--- a/src/file_distribution/file_writer.rs
+++ b/src/file_distribution/file_writer.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! # File Writer Pool
 //!
 //! This module implements a thread pool for asynchronous file writing operations.

--- a/src/file_distribution/mod.rs
+++ b/src/file_distribution/mod.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 pub mod assembler;
 pub mod common;
 pub mod data_plane;

--- a/src/file_distribution/object_store_download.rs
+++ b/src/file_distribution/object_store_download.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! # Object Store Downloader
 //!
 //! This module defines the core data plane logic for downloading files from an object store

--- a/src/file_distribution/p2p_server.rs
+++ b/src/file_distribution/p2p_server.rs
@@ -72,6 +72,16 @@ pub enum P2pServerError {
 
     #[error("Health check failed: {0}")]
     HealthCheck(#[from] reqwest::Error),
+
+    #[error("Failed to bind to {addr}: {source}")]
+    Bind {
+        addr: SocketAddr,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Server thread exited before signaling readiness")]
+    StartupAborted,
 }
 
 impl From<P2pServerError> for PyErr {
@@ -378,7 +388,7 @@ impl P2pServer {
 impl P2pServer {
     #[new]
     #[pyo3(signature = (port, node_id, is_test=false))]
-    pub fn new(port: u16, node_id: String, is_test: bool) -> Self {
+    pub fn new(port: u16, node_id: String, is_test: bool) -> Result<Self, P2pServerError> {
         // Reset the counter to prevent accumulation from previous instances
         ACTIVE_UPLOADS.store(0, Ordering::Relaxed);
 
@@ -392,6 +402,11 @@ impl P2pServer {
         };
         let server_config = Arc::new(ServerConfig { node_id, is_test });
 
+        // Signal readiness back to the caller once the TCP listener is bound.
+        // This prevents a race where the server isn't yet accepting connections
+        // when the first health check arrives.
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), std::io::Error>>();
+
         let server_handle = thread::spawn(move || {
             let rt = Runtime::new().unwrap();
             rt.block_on(async {
@@ -399,18 +414,27 @@ impl P2pServer {
                     Ok(listener) => listener,
                     Err(e) => {
                         eprintln!("Failed to bind to {}: {}", addr, e);
+                        let _ = ready_tx.send(Err(e));
                         return;
                     }
                 };
                 println!("P2P server listening on {}", addr);
+                if ready_tx.send(Ok(())).is_err() {
+                    // Caller already gave up; don't bother serving.
+                    return;
+                }
                 server_main(shutdown_rx, listener, server_config).await;
             });
         });
 
-        P2pServer {
-            shutdown_tx: shutdown_tx_clone,
-            server_handle: Some(server_handle),
-            addr,
+        match ready_rx.recv() {
+            Ok(Ok(())) => Ok(P2pServer {
+                shutdown_tx: shutdown_tx_clone,
+                server_handle: Some(server_handle),
+                addr,
+            }),
+            Ok(Err(source)) => Err(P2pServerError::Bind { addr, source }),
+            Err(_) => Err(P2pServerError::StartupAborted),
         }
     }
 

--- a/src/file_distribution/unpacker.rs
+++ b/src/file_distribution/unpacker.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! # Unpacker Worker Pool
 //!
 //! This module is responsible for unpacking archived files.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 pub mod file_distribution;
 pub mod pipelines;
 pub mod utils;

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 pub mod private;
 
 use pyo3::prelude::*;

--- a/src/pipelines/private/mod.rs
+++ b/src/pipelines/private/mod.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 pub mod scheduling;
 
 use pyo3::prelude::*;

--- a/src/pipelines/private/scheduling/approx_utils.rs
+++ b/src/pipelines/private/scheduling/approx_utils.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 pub const EPSILON: f64 = 1e-6;
 
 /// Compare two floats with epsilon tolerance.

--- a/src/pipelines/private/scheduling/autoscaling_algorithms.rs
+++ b/src/pipelines/private/scheduling/autoscaling_algorithms.rs
@@ -2250,7 +2250,7 @@ mod tests {
         // run of the autoscaler produces no changes.
 
         // Create a cluster with plenty of resources
-        let cluster = make_cluster(100, 24, 8, 4, 4, false);
+        let cluster = make_cluster(100, 24, 8, false);
 
         let mut stages = Vec::new();
         let mut speeds = Vec::new();
@@ -2259,9 +2259,9 @@ mod tests {
         stages.push(ds::ProblemStage {
             name: format!("stage_{}", cur_stage_idx),
             stage_batch_size: 1,
-            worker_shape: rds::WorkerShapeWrapper {
-                inner: rds::WorkerShape::CpuOnly(rds::CpuOnly { num_cpus: 1.0 }),
-            },
+            worker_shape: rds::WorkerShape::CpuOnly(rds::CpuOnly {
+                num_cpus: rds::FixedUtil::from_num(1.0),
+            }),
             requested_num_workers: None,
             over_provision_factor: None,
         });
@@ -2272,14 +2272,10 @@ mod tests {
             stages.push(ds::ProblemStage {
                 name: format!("stage_{}", cur_stage_idx),
                 stage_batch_size: 1,
-                worker_shape: rds::WorkerShapeWrapper {
-                    inner: rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
-                        num_gpus: 0.1,
-                        num_cpus: 1.0,
-                        num_nvdecs: 0,
-                        num_nvencs: 0,
-                    }),
-                },
+                worker_shape: rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+                    gpu_fraction: rds::FixedUtil::from_num(0.1),
+                    num_cpus: rds::FixedUtil::from_num(1.0),
+                }),
                 requested_num_workers: None,
                 over_provision_factor: None,
             });
@@ -2291,14 +2287,10 @@ mod tests {
             stages.push(ds::ProblemStage {
                 name: format!("stage_{}", cur_stage_idx),
                 stage_batch_size: 1,
-                worker_shape: rds::WorkerShapeWrapper {
-                    inner: rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
-                        num_gpus: 0.1,
-                        num_cpus: 1.0,
-                        num_nvdecs: 1,
-                        num_nvencs: 2,
-                    }),
-                },
+                worker_shape: rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+                    gpu_fraction: rds::FixedUtil::from_num(0.1),
+                    num_cpus: rds::FixedUtil::from_num(1.0),
+                }),
                 requested_num_workers: None,
                 over_provision_factor: None,
             });
@@ -2309,9 +2301,9 @@ mod tests {
         stages.push(ds::ProblemStage {
             name: format!("stage_{}", cur_stage_idx),
             stage_batch_size: 1,
-            worker_shape: rds::WorkerShapeWrapper {
-                inner: rds::WorkerShape::CpuOnly(rds::CpuOnly { num_cpus: 1.0 }),
-            },
+            worker_shape: rds::WorkerShape::CpuOnly(rds::CpuOnly {
+                num_cpus: rds::FixedUtil::from_num(1.0),
+            }),
             requested_num_workers: None,
             over_provision_factor: None,
         });
@@ -2343,7 +2335,7 @@ mod tests {
                 .zip(solution1.stages.iter())
                 .map(|(p, s)| ds::ProblemStageState {
                     stage_name: p.name.clone(),
-                    workers: s.new_workers.clone(),
+                    worker_groups: s.new_workers.clone(),
                     slots_per_worker: s.slots_per_worker,
                     is_finished: false,
                 })

--- a/src/pipelines/private/scheduling/data_structures.rs
+++ b/src/pipelines/private/scheduling/data_structures.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! Data structures used by autoscaling algorithms and simulations.
 //!
 //! This module presents an interface for autoscaling algorithms. This interface formulates the autoscaling information as

--- a/src/pipelines/private/scheduling/mod.rs
+++ b/src/pipelines/private/scheduling/mod.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 pub mod allocator;
 pub mod approx_utils;
 pub mod autoscaling_algorithms;

--- a/src/pipelines/private/scheduling/resources.rs
+++ b/src/pipelines/private/scheduling/resources.rs
@@ -752,7 +752,11 @@ impl NodeResources {
     }
 
     pub fn used_pool(&self) -> PoolOfResources {
-        let gpu_used: f32 = self.gpus.iter().map(|g| g.used_fraction.to_num::<f32>()).sum();
+        let gpu_used: f32 = self
+            .gpus
+            .iter()
+            .map(|g| g.used_fraction.to_num::<f32>())
+            .sum();
         PoolOfResources {
             cpus: self.used_cpus.to_num::<f32>(),
             gpus: gpu_used,
@@ -760,7 +764,11 @@ impl NodeResources {
     }
 
     pub fn free_pool(&self) -> PoolOfResources {
-        let gpu_free: f32 = self.gpus.iter().map(|g| 1.0 - g.used_fraction.to_num::<f32>()).sum();
+        let gpu_free: f32 = self
+            .gpus
+            .iter()
+            .map(|g| 1.0 - g.used_fraction.to_num::<f32>())
+            .sum();
         PoolOfResources {
             cpus: self.total_cpus.to_num::<f32>() - self.used_cpus.to_num::<f32>(),
             gpus: gpu_free,
@@ -1014,15 +1022,23 @@ impl ClusterResources {
     }
 
     pub fn used_pool(&self) -> PoolOfResources {
-        self.nodes.values().fold(PoolOfResources::default(), |acc, n| acc.add(&n.used_pool()))
+        self.nodes
+            .values()
+            .fold(PoolOfResources::default(), |acc, n| acc.add(&n.used_pool()))
     }
 
     pub fn free_pool(&self) -> PoolOfResources {
-        self.nodes.values().fold(PoolOfResources::default(), |acc, n| acc.add(&n.free_pool()))
+        self.nodes
+            .values()
+            .fold(PoolOfResources::default(), |acc, n| acc.add(&n.free_pool()))
     }
 
     pub fn total_pool(&self) -> PoolOfResources {
-        self.nodes.values().fold(PoolOfResources::default(), |acc, n| acc.add(&n.total_pool()))
+        self.nodes
+            .values()
+            .fold(PoolOfResources::default(), |acc, n| {
+                acc.add(&n.total_pool())
+            })
     }
 
     pub fn make_detailed_utilization_table(&self) -> String {

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use env_logger::Env;
 use log::debug;
 use pyo3::prelude::*;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 pub mod logging;
 pub mod module_builders;
 pub mod timing;

--- a/src/utils/module_builders.rs
+++ b/src/utils/module_builders.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyNone};
 use pyo3::{PyClass, ffi};


### PR DESCRIPTION
Triggers

- Runs on pushes to main and on all pull requests; concurrent runs on the same ref cancel in-flight ones.

Jobs

- Python Lint (PRs only, x86_64) — builds the Rust extension with maturin, checks NVIDIA license headers on .py / .pyi / .rs, runs ruff format --check, ruff check (0.12.7), and pyright (1.1.403).
- Python Tests (x86_64 + arm64) — builds the extension with maturin, then runs pytest -m 'not slow' followed by pytest -m 'slow'.
- Rust Lint (PRs only, x86_64) — cargo fmt --check, cargo check --all-targets, cargo clippy --all-targets -- -D warnings.
- Rust Tests (x86_64 + arm64) — cargo test plus cargo test --release --features release-tests.
- CI Pass — single required gate; requires tests to succeed and tolerates skipped lint jobs on main.

Infrastructure:

- Runners: ubuntu-22.04 / ubuntu-22.04-arm (with caching for Rust builds).