### PR TITLE
fix: add backlog-aware scale-down guard to prevent GPU starvation at drain-tail

### DIFF
--- a/cosmos_xenna/pipelines/private/specs.py
+++ b/cosmos_xenna/pipelines/private/specs.py
@@ -374,11 +374,14 @@ class StreamingSpecificSpec:
     executor_verbosity_level: VerbosityLevel = VerbosityLevel.INFO
     # Backlog-aware scale-down guard.
     #
-    # When True (default), the autoscaler clamps Rust-proposed worker
-    # deletions so that the surviving workers can still drain the queued
-    # backlog (upstream queue + this pool's own queue) at the pre-scaling
-    # ``slots_per_actor``.
-    enable_backlog_aware_scaledown: bool = True
+    # Default ``False`` - Rust-proposed worker deletions pass through unchanged.
+    #
+    # Set ``True`` to have the autoscaler clamp deletions so that the surviving workers
+    # on each pool can still drain the queued backlog (upstream queue + this pool's own queue)
+    # at the pre-scaling ``slots_per_actor``. This protects downstream stages from the drain-tail
+    # starvation pattern where source completion triggers aggressive CPU-stage scale-down before
+    # queued work has drained.
+    enable_backlog_aware_scaledown: bool = False
 
 
 @attrs.define

--- a/cosmos_xenna/pipelines/private/specs.py
+++ b/cosmos_xenna/pipelines/private/specs.py
@@ -372,6 +372,13 @@ class StreamingSpecificSpec:
     # Add verbosity level for the autoscaler
     autoscaler_verbosity_level: VerbosityLevel = VerbosityLevel.NONE
     executor_verbosity_level: VerbosityLevel = VerbosityLevel.INFO
+    # Backlog-aware scale-down guard.
+    #
+    # When True (default), the autoscaler clamps Rust-proposed worker
+    # deletions so that the surviving workers can still drain the queued
+    # backlog (upstream queue + this pool's own queue) at the pre-scaling
+    # ``slots_per_actor``.
+    enable_backlog_aware_scaledown: bool = True
 
 
 @attrs.define

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -247,8 +247,9 @@ def _required_workers_for_stage(
         every task already dispatched to a slot; deleting below this would
         forcefully return tasks to the queue and starve downstream stages.
       * ``ceil(backlog_samples / (slots_per_actor * stage_batch_size))`` -
-        enough actors to drain the queued backlog at full per-actor
-        utilisation within one autoscale cycle.
+        enough actors to provide slot-and-batch capacity for the currently
+        queued backlog so work is not stranded waiting for actor capacity
+        and downstream stages are less likely to be starved.
 
     Args:
         slots_per_actor: Concurrent task slots per actor. Must be ``> 0``.

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -290,6 +290,47 @@ class Autoscaler:
     The `Autoscaler` is implemented as a context manager to ensure that the
     background thread executor is properly shut down upon exit.
 
+    Multi-stage allocation policy
+    -----------------------------
+    The Rust ``run_fragmentation_autoscaler`` (driven by
+    ``FragmentationBasedAutoscaler``) decides per-stage worker counts in
+    four phases on every cycle, using a single shared ``ClusterResources``
+    snapshot:
+
+      * Phase 1 - honour ``requested_num_workers`` for manual stages.
+      * Phase 2 (FLOOR) - every non-manual, non-finished stage gets at
+        least one worker. Prevents downstream starvation when an
+        upstream stage would otherwise consume the whole cluster.
+      * Phase 3 (PREEMPTION) - max-min loop: while the slowest stage
+        can be grown (directly via free CPU, or by stealing one worker
+        from a "donor" stage that stays above the current minimum
+        throughput after losing it), keep doing so. This is the
+        mechanism that re-balances workers from over-provisioned
+        upstream stages toward a slower downstream bottleneck.
+      * Phase 4 (HEADROOM) - controlled over-allocation up to
+        ``base_min * overallocation_target`` (default 1.5).
+
+    Apply-side invariants (this class + ``ActorPool``):
+
+      * The streaming main loop runs a two-pass apply each cycle:
+        first ``pool.delete_worker_groups()`` on every active pool to
+        return resources to the cluster, then ``pool.update()`` on
+        every active pool to run creations. This guarantees that
+        CPU/GPU freed by a delete in stage N is visible to a create
+        in stage M of the same cycle.
+      * ``ActorPool._adjust_actors`` preserves the same
+        delete-before-create ordering within a single pool. In the
+        streaming path the ``delete_worker_groups()`` two-pass has
+        already drained pending deletions before ``_adjust_actors``
+        runs, so this in-pool ordering is primarily a safety net
+        (and the canonical ordering in batch mode).
+      * Even with that ordering, the planner's per-node placement is
+        a snapshot from up to ``autoscale_interval_s`` ago. If actual
+        per-node CPU has drifted (a worker died, or another stage
+        consumed CPU outside the planner's view), an individual
+        ``_add_worker_group`` can still surface ``AllocationError``
+        and is retried on the next cycle.
+
     Attributes:
         _verbosity_level: The level of logging verbosity.
         _allocator: An instance of `WorkerAllocator` to manage worker resources.
@@ -300,6 +341,11 @@ class Autoscaler:
             any previous results have been applied.
         _autoscale_start_time: The timestamp when the last autoscaling calculation
             was started.
+        _enable_backlog_guard: When True, ``apply_autoscale_result_if_ready``
+            clamps Rust-proposed deletions so surviving workers can still
+            drain the queued backlog. When False, all deletions pass through
+            unchanged (original main-branch behavior). Sourced from
+            ``StreamingSpecificSpec.enable_backlog_aware_scaledown``.
     """
 
     # Floor for the backlog-aware scale-down guard (see
@@ -336,6 +382,7 @@ class Autoscaler:
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         self._autoscale_future: Optional[concurrent.futures.Future] = None
         self._autoscale_start_time: float = 0.0
+        self._enable_backlog_guard: bool = pipeline_spec.config.mode_specific.enable_backlog_aware_scaledown
 
     def __enter__(self) -> Autoscaler:
         """Enters the context manager."""
@@ -492,7 +539,7 @@ class Autoscaler:
             # computed from the pre-mutation snapshot
             deletions = list(result.deleted_workers)
             proposed_delete_count = len(deletions)
-            if proposed_delete_count > 0:
+            if self._enable_backlog_guard and proposed_delete_count > 0:
                 backlog_samples = upstream_queue_lens[idx] + pre_pool_queued
                 required_workers = _required_workers_for_stage(
                     slots_per_actor=pre_slots_per_actor,

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -255,8 +255,10 @@ def _required_workers_for_stage(
         stage_batch_size: Batch size declared by the stage. Must be ``> 0``.
         inflight_slots: Actor slots currently executing tasks. Must be
             ``>= 0``.
-        backlog_samples: Tasks waiting for an actor slot (upstream queue
-            + pool's internal task queue). Must be ``>= 0``.
+        backlog_samples: Outstanding work waiting for an actor slot,
+            expressed in samples (upstream queue length plus pool task
+            queue size multiplied by ``stage_batch_size``). Must be
+            ``>= 0``.
 
     Returns:
         The minimum worker count a proposed scale-down must leave alive.
@@ -573,7 +575,13 @@ class Autoscaler:
             deletions = list(result.deleted_workers)
             proposed_delete_count = len(deletions)
             if self._enable_backlog_guard and proposed_delete_count > 0 and not stages_is_dones[idx]:
-                backlog_samples = upstream_queue_lens[idx] + pre_pool_queued
+                # Unit normalization: ``upstream_queue_lens[idx]`` is sample-
+                # denominated (``Queue.__len__`` counts individual ObjectRefs),
+                # but ``pool.num_queued_tasks`` returns pre-batched Tasks.
+                # Multiply the pool count by ``stage_batch_sizes[idx]`` so the
+                # combined ``backlog_samples`` value passed to the helper is
+                # uniformly in samples.
+                backlog_samples = upstream_queue_lens[idx] + pre_pool_queued * stage_batch_sizes[idx]
                 required_workers = _required_workers_for_stage(
                     slots_per_actor=pre_slots_per_actor,
                     stage_batch_size=stage_batch_sizes[idx],

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -352,9 +352,10 @@ class Autoscaler:
     # ``_required_workers_for_stage``). Keeps one actor alive on every
     # *active* stage so work arriving after a temporary upstream lull
     # is processed immediately instead of paying a cold-start cycle.
-    # Finished-stage teardown bypasses the guard via ``is_done`` in
-    # ``run_pipeline``, and end-of-pipeline teardown happens via the
-    # ``Autoscaler`` context exit, so this floor never strands actors.
+    # ``apply_autoscale_result_if_ready`` bypasses this floor for stages
+    # whose ``stages_is_dones[idx]`` flag is True, and end-of-pipeline
+    # teardown happens via the ``Autoscaler`` context exit + ``pool.stop()``,
+    # so this floor never strands actors.
     MIN_WORKERS_PER_STAGE: typing.ClassVar[int] = 1
 
     def __init__(
@@ -372,17 +373,19 @@ class Autoscaler:
             cluster_resources: The available resources in the cluster.
             verbosity_level: The verbosity level for logging.
         """
+        mode_specific = pipeline_spec.config.mode_specific
+        assert mode_specific is not None, "Autoscaler requires StreamingSpecificSpec; got mode_specific=None"
         self._verbosity_level = verbosity_level
         self._allocator = worker_allocator
         self._algorithm = autoscaling_algorithms.FragmentationBasedAutoscaler(
-            pipeline_spec.config.mode_specific.autoscale_speed_estimation_window_duration_s,
-            pipeline_spec.config.mode_specific.autoscale_speed_estimation_min_data_points,
+            mode_specific.autoscale_speed_estimation_window_duration_s,
+            mode_specific.autoscale_speed_estimation_min_data_points,
         )
         self._algorithm.setup(_make_problem_from_pipeline_spec(pipeline_spec, cluster_resources))
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         self._autoscale_future: Optional[concurrent.futures.Future] = None
         self._autoscale_start_time: float = 0.0
-        self._enable_backlog_guard: bool = pipeline_spec.config.mode_specific.enable_backlog_aware_scaledown
+        self._enable_backlog_guard: bool = mode_specific.enable_backlog_aware_scaledown
 
     def __enter__(self) -> Autoscaler:
         """Enters the context manager."""
@@ -458,21 +461,28 @@ class Autoscaler:
         pools: list[actor_pool.ActorPool],
         upstream_queue_lens: list[int],
         stage_batch_sizes: list[int],
+        stages_is_dones: list[bool],
     ) -> None:
         """Apply a completed autoscaling result, clamping unsafe deletions.
 
-        No-op if no result is pending. Otherwise, for each stage, the Rust
-        autoscaler's proposed worker deletions are capped so the surviving
+        No-op if no result is pending. Otherwise, for each *active* stage, the
+        Rust autoscaler's proposed worker deletions are capped so the surviving
         workers can still (a) hold every task already dispatched to an actor
         slot and (b) drain the queued backlog at full per-actor utilisation.
         Deletions are only reduced, never grown.
 
-        This guard exists because the Rust ``FragmentationBasedAutoscaler``
-        optimises throughput fairness and is blind to queue depth and
-        in-flight work: when the upstream source finishes, measured throughput
+        Stages whose ``stages_is_dones[idx]`` flag is ``True`` bypass the guard
+        entirely: their proposed deletions pass through unchanged so the
+        ``MIN_WORKERS_PER_STAGE`` floor never strands actors after the work
+        upstream of them has finished. This complements ``run_pipeline``,
+        which calls ``pool.stop()`` once a stage transitions to done; the
+        bypass guarantees the autoscaler queue does not first try to leave
+        an actor alive on a stage the main loop is about to tear down.
+
+        When the upstream source finishes, measured throughput
         falls to zero and Rust can propose deleting most of a stage's actors
         in a single cycle (e.g. ``20 -> 2``), stranding tasks already in the
-        queue and starving downstream GPU stages.
+        queue and starving downstream stages.
 
         ::
 
@@ -499,24 +509,43 @@ class Autoscaler:
             stage_batch_sizes: Per-stage declared ``stage_batch_size`` values
                 (each must be ``>= 1``). Must have the same length as
                 ``pools``.
+            stages_is_dones: Per-stage completion flags. ``True`` means the
+                stage has finished consuming all upstream work and is being
+                torn down by the main loop; the guard skips clamping for
+                those stages so the floor never strands a worker. Must have
+                the same length as ``pools``.
 
         Raises:
-            ValueError: If ``upstream_queue_lens`` or ``stage_batch_sizes``
-                has a length different from ``pools``. This is a caller-side
-                contract violation, not a runtime condition.
+            ValueError: If ``upstream_queue_lens``, ``stage_batch_sizes``,
+                ``stages_is_dones``, or ``autoscale_result.stages`` has a
+                length different from ``pools``. These are caller-side or
+                planner-side contract violations, not runtime conditions.
 
         """
         if self._autoscale_future is None or not self._autoscale_future.done():
             return
 
-        if len(upstream_queue_lens) != len(pools) or len(stage_batch_sizes) != len(pools):
+        if (
+            len(upstream_queue_lens) != len(pools)
+            or len(stage_batch_sizes) != len(pools)
+            or len(stages_is_dones) != len(pools)
+        ):
             raise ValueError(
                 f"Guard inputs have mismatched lengths: pools={len(pools)}, "
                 f"upstream_queue_lens={len(upstream_queue_lens)}, "
-                f"stage_batch_sizes={len(stage_batch_sizes)}"
+                f"stage_batch_sizes={len(stage_batch_sizes)}, "
+                f"stages_is_dones={len(stages_is_dones)}"
             )
 
         autoscale_result: data_structures.Solution = self._autoscale_future.result()
+        if len(autoscale_result.stages) != len(pools):
+            # Mismatched lengths would silently truncate the shorter side via
+            # ``zip``, leaving stages with stale worker counts. This is a
+            # planner-side invariant violation, surface it explicitly.
+            raise ValueError(
+                f"Autoscale result stage count {len(autoscale_result.stages)} "
+                f"does not match pool count {len(pools)}; planner contract violated."
+            )
 
         for idx, (result, pool) in enumerate(zip(autoscale_result.stages, pools)):
             # Snapshot pre-mutation state: the guard must reason about the
@@ -536,10 +565,12 @@ class Autoscaler:
             )
 
             # Clamp Rust's proposed deletions to the backlog-aware floor
-            # computed from the pre-mutation snapshot
+            # computed from the pre-mutation snapshot. Skip the clamp for
+            # finished stages so end-of-stage teardown can release resources
+            # without the floor stranding actors.
             deletions = list(result.deleted_workers)
             proposed_delete_count = len(deletions)
-            if self._enable_backlog_guard and proposed_delete_count > 0:
+            if self._enable_backlog_guard and proposed_delete_count > 0 and not stages_is_dones[idx]:
                 backlog_samples = upstream_queue_lens[idx] + pre_pool_queued
                 required_workers = _required_workers_for_stage(
                     slots_per_actor=pre_slots_per_actor,
@@ -864,7 +895,7 @@ def run_pipeline(
             upstream_queue_lens: list[int] = [
                 len(input_queue) if idx == 0 else len(queues[idx - 1]) for idx in range(len(pools))
             ]
-            autoscaler.apply_autoscale_result_if_ready(pools, upstream_queue_lens, stage_batch_sizes)
+            autoscaler.apply_autoscale_result_if_ready(pools, upstream_queue_lens, stage_batch_sizes, stage_is_dones)
             new_stats.auto_scaling_apply_end = time.time()
 
             # Delete all the actors first. We do this as a separate step from "update()" because we may need

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -230,6 +230,56 @@ def make_problem_worker_state_from_worker_state(
     return data_structures.ProblemWorkerGroupState.make(state.id, state.allocations)
 
 
+def _required_workers_for_stage(
+    slots_per_actor: int,
+    stage_batch_size: int,
+    inflight_slots: int,
+    backlog_samples: int,
+) -> int:
+    """Compute the minimum workers a stage must retain to preserve progress.
+
+    Returns the max of three lower bounds:
+
+      * ``Autoscaler.MIN_WORKERS_PER_STAGE`` - keeps the stage alive so the
+        autoscaler can scale it back up once upstream data resumes (avoids
+        cold-start latency during temporary upstream lulls).
+      * ``ceil(inflight_slots / slots_per_actor)`` - enough actors to hold
+        every task already dispatched to a slot; deleting below this would
+        forcefully return tasks to the queue and starve downstream stages.
+      * ``ceil(backlog_samples / (slots_per_actor * stage_batch_size))`` -
+        enough actors to drain the queued backlog at full per-actor
+        utilisation within one autoscale cycle.
+
+    Args:
+        slots_per_actor: Concurrent task slots per actor. Must be ``> 0``.
+        stage_batch_size: Batch size declared by the stage. Must be ``> 0``.
+        inflight_slots: Actor slots currently executing tasks. Must be
+            ``>= 0``.
+        backlog_samples: Tasks waiting for an actor slot (upstream queue
+            + pool's internal task queue). Must be ``>= 0``.
+
+    Returns:
+        The minimum worker count a proposed scale-down must leave alive.
+
+    Raises:
+        ValueError: If any argument violates the bounds above.
+
+    """
+    if slots_per_actor <= 0:
+        raise ValueError(f"slots_per_actor must be > 0, got {slots_per_actor}")
+    if stage_batch_size <= 0:
+        raise ValueError(f"stage_batch_size must be > 0, got {stage_batch_size}")
+    if inflight_slots < 0:
+        raise ValueError(f"inflight_slots must be >= 0, got {inflight_slots}")
+    if backlog_samples < 0:
+        raise ValueError(f"backlog_samples must be >= 0, got {backlog_samples}")
+
+    workers_for_inflight = math.ceil(inflight_slots / slots_per_actor)
+    capacity_per_actor = slots_per_actor * stage_batch_size
+    workers_for_backlog = math.ceil(backlog_samples / capacity_per_actor)
+    return max(Autoscaler.MIN_WORKERS_PER_STAGE, workers_for_inflight, workers_for_backlog)
+
+
 class Autoscaler:
     """Manages the autoscaling of pipeline stages in a streaming execution mode.
 
@@ -251,6 +301,15 @@ class Autoscaler:
         _autoscale_start_time: The timestamp when the last autoscaling calculation
             was started.
     """
+
+    # Floor for the backlog-aware scale-down guard (see
+    # ``_required_workers_for_stage``). Keeps one actor alive on every
+    # *active* stage so work arriving after a temporary upstream lull
+    # is processed immediately instead of paying a cold-start cycle.
+    # Finished-stage teardown bypasses the guard via ``is_done`` in
+    # ``run_pipeline``, and end-of-pipeline teardown happens via the
+    # ``Autoscaler`` context exit, so this floor never strands actors.
+    MIN_WORKERS_PER_STAGE: typing.ClassVar[int] = 1
 
     def __init__(
         self,
@@ -347,39 +406,125 @@ class Autoscaler:
         problem_state = self._make_problem_state(pools, stages_is_dones)
         self._autoscale_future = self._executor.submit(self._algorithm.autoscale, time.time(), problem_state)
 
-    def apply_autoscale_result_if_ready(self, pools: list[actor_pool.ActorPool]) -> None:
-        """Applies the result of a completed autoscaling calculation.
+    def apply_autoscale_result_if_ready(
+        self,
+        pools: list[actor_pool.ActorPool],
+        upstream_queue_lens: list[int],
+        stage_batch_sizes: list[int],
+    ) -> None:
+        """Apply a completed autoscaling result, clamping unsafe deletions.
 
-        If the calculation is not yet finished, this method does nothing. Once the
-        result is applied, it updates the actor pools with new worker
-        configurations.
+        No-op if no result is pending. Otherwise, for each stage, the Rust
+        autoscaler's proposed worker deletions are capped so the surviving
+        workers can still (a) hold every task already dispatched to an actor
+        slot and (b) drain the queued backlog at full per-actor utilisation.
+        Deletions are only reduced, never grown.
+
+        This guard exists because the Rust ``FragmentationBasedAutoscaler``
+        optimises throughput fairness and is blind to queue depth and
+        in-flight work: when the upstream source finishes, measured throughput
+        falls to zero and Rust can propose deleting most of a stage's actors
+        in a single cycle (e.g. ``20 -> 2``), stranding tasks already in the
+        queue and starving downstream GPU stages.
+
+        ::
+
+            Drain-tail cliff (upstream stops at t0; queue still = Q > 0 tasks):
+
+              workers
+                 ^
+              W0 +=*.
+                 |   `*-.     Rust: throughput=0 -> cuts workers hard
+                 |       `*-.____________________   (queue stranded, GPU idle)
+                 |
+                 |    *-.     guard: w >= ceil(queue / per-actor-capacity)
+                 |       `*-.__   (shrinks only as the queue actually drains)
+               1 +-------------*-.-.-.===========>
+                 +-------t0---------------------------> time
 
         Args:
-            pools: The list of actor pools to update with the new scaling results.
+            pools: Actor pools to update with the new scaling results.
+            upstream_queue_lens: Per-stage upstream queue lengths. Entry
+                ``[i]`` is the number of tasks waiting to be pulled into
+                ``pools[i]`` (the pipeline's input queue for stage ``0``, or
+                ``queues[i - 1]`` for downstream stages). Must have the same
+                length as ``pools``.
+            stage_batch_sizes: Per-stage declared ``stage_batch_size`` values
+                (each must be ``>= 1``). Must have the same length as
+                ``pools``.
+
+        Raises:
+            ValueError: If ``upstream_queue_lens`` or ``stage_batch_sizes``
+                has a length different from ``pools``. This is a caller-side
+                contract violation, not a runtime condition.
+
         """
-        if self._autoscale_future is not None and self._autoscale_future.done():
-            autoscale_result: data_structures.Solution = self._autoscale_future.result()
+        if self._autoscale_future is None or not self._autoscale_future.done():
+            return
 
-            for result, pool in zip(autoscale_result.stages, pools):
-                pool.set_num_slots_per_actor(result.slots_per_worker)
-                logger.debug(
-                    f"Autoscale result for pool {pool.name}: {len(result.new_workers)} new workers, "
-                    f"{len(result.deleted_workers)} deleted workers"
+        if len(upstream_queue_lens) != len(pools) or len(stage_batch_sizes) != len(pools):
+            raise ValueError(
+                f"Guard inputs have mismatched lengths: pools={len(pools)}, "
+                f"upstream_queue_lens={len(upstream_queue_lens)}, "
+                f"stage_batch_sizes={len(stage_batch_sizes)}"
+            )
+
+        autoscale_result: data_structures.Solution = self._autoscale_future.result()
+
+        for idx, (result, pool) in enumerate(zip(autoscale_result.stages, pools)):
+            # Snapshot pre-mutation state: the guard must reason about the
+            # ``slots_per_actor`` value under which the current in-flight work
+            # was committed. ``set_num_slots_per_actor`` below only *increases*
+            # slots, so reading after it would underestimate the number of
+            # workers needed to hold the in-flight tasks.
+            pre_slots_per_actor = pool.slots_per_actor
+            pre_inflight_slots = pool.num_used_slots
+            pre_ready_actors = pool.num_ready_actors
+            pre_pool_queued = pool.num_queued_tasks
+
+            pool.set_num_slots_per_actor(result.slots_per_worker)
+            logger.debug(
+                f"Autoscale result for pool {pool.name}: {len(result.new_workers)} new workers, "
+                f"{len(result.deleted_workers)} deleted workers"
+            )
+
+            # Clamp Rust's proposed deletions to the backlog-aware floor
+            # computed from the pre-mutation snapshot
+            deletions = list(result.deleted_workers)
+            proposed_delete_count = len(deletions)
+            if proposed_delete_count > 0:
+                backlog_samples = upstream_queue_lens[idx] + pre_pool_queued
+                required_workers = _required_workers_for_stage(
+                    slots_per_actor=pre_slots_per_actor,
+                    stage_batch_size=stage_batch_sizes[idx],
+                    inflight_slots=pre_inflight_slots,
+                    backlog_samples=backlog_samples,
                 )
-                for w in result.new_workers:
-                    logger.debug(f"Adding actor to create: {w.to_worker_group(pool.name)}")
-                    pool.add_actor_to_create(w.to_worker_group(pool.name))
+                max_safe_deletions = max(0, pre_ready_actors - required_workers)
+                allowed_delete_count = min(proposed_delete_count, max_safe_deletions)
+                if allowed_delete_count < proposed_delete_count:
+                    logger.info(
+                        f"Clamped scale-down for stage {pool.name}: "
+                        f"current={pre_ready_actors}, required={required_workers}, "
+                        f"proposed_delete={proposed_delete_count}, allowed_delete={allowed_delete_count}, "
+                        f"upstream_q={upstream_queue_lens[idx]}, pool_q={pre_pool_queued}, "
+                        f"inflight_slots={pre_inflight_slots}, slots_per_actor={pre_slots_per_actor}, "
+                        f"stage_batch_size={stage_batch_sizes[idx]}"
+                    )
+                deletions = deletions[:allowed_delete_count]
 
-                for w in result.deleted_workers:
-                    logger.debug(f"Adding actor to delete: {w.to_worker_group(pool.name)}")
-                    pool.add_actor_to_delete(w.to_worker_group(pool.name))
+            for w in result.new_workers:
+                logger.debug(f"Adding actor to create: {w.to_worker_group(pool.name)}")
+                pool.add_actor_to_create(w.to_worker_group(pool.name))
 
-            self._autoscale_future = None
-            autoscale_end_time = time.time()
-            if autoscale_end_time - self._autoscale_start_time > 1.0:
-                logger.warning(
-                    f"Applying autoscale results took {autoscale_end_time - self._autoscale_start_time} seconds"
-                )
+            for w in deletions:
+                logger.debug(f"Adding actor to delete: {w.to_worker_group(pool.name)}")
+                pool.add_actor_to_delete(w.to_worker_group(pool.name))
+
+        self._autoscale_future = None
+        autoscale_end_time = time.time()
+        if autoscale_end_time - self._autoscale_start_time > 1.0:
+            logger.warning(f"Applying autoscale results took {autoscale_end_time - self._autoscale_start_time} seconds")
 
 
 def _verify_enough_resources(pipeline_spec: specs.PipelineSpec, cluster_resources: resources.ClusterResources) -> None:
@@ -632,6 +777,13 @@ def run_pipeline(
     # Create a vector used to track whether a stages are finished or not.
     stage_is_dones = [False for _ in pools]
 
+    # Static per-stage ``stage_batch_size`` values used by the backlog-aware
+    # scale-down guard. Stage batch sizes do not change over the
+    # pipeline's lifetime, so build once outside the main loop.
+    stage_batch_sizes: list[int] = [
+        typing.cast(specs.StageSpec, stage).stage.stage_batch_size for stage in pipeline_spec.stages
+    ]
+
     autoscale_rate_limiter = timing.RateLimitChecker(1.0 / pipeline_spec.config.mode_specific.autoscale_interval_s)
     rate_limiter = timing.RateLimiter(_MAX_MAIN_LOOP_RATE_HZ)
 
@@ -658,8 +810,14 @@ def run_pipeline(
         while True:
             new_stats = StreamingExecutorTiming(time.time())
 
-            # Apply autoscale results if they are ready.
-            autoscaler.apply_autoscale_result_if_ready(pools)
+            # Apply autoscale results if they are ready. Compute the
+            # per-stage upstream queue lengths used by the backlog-aware
+            # scale-down guard: stage 0 draws from the pipeline
+            # input queue; every other stage draws from ``queues[idx - 1]``.
+            upstream_queue_lens: list[int] = [
+                len(input_queue) if idx == 0 else len(queues[idx - 1]) for idx in range(len(pools))
+            ]
+            autoscaler.apply_autoscale_result_if_ready(pools, upstream_queue_lens, stage_batch_sizes)
             new_stats.auto_scaling_apply_end = time.time()
 
             # Delete all the actors first. We do this as a separate step from "update()" because we may need

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -341,11 +341,13 @@ class Autoscaler:
             any previous results have been applied.
         _autoscale_start_time: The timestamp when the last autoscaling calculation
             was started.
-        _enable_backlog_guard: When True, ``apply_autoscale_result_if_ready``
-            clamps Rust-proposed deletions so surviving workers can still
-            drain the queued backlog. When False, all deletions pass through
-            unchanged (original main-branch behavior). Sourced from
+        _enable_backlog_guard: Sourced from
             ``StreamingSpecificSpec.enable_backlog_aware_scaledown``.
+            Default False - all Rust-proposed deletions
+            pass through unchanged. When True (opt-in),
+            ``apply_autoscale_result_if_ready`` clamps deletions so
+            surviving workers can still drain the queued backlog at the
+            pre-scaling ``slots_per_actor``.
     """
 
     # Floor for the backlog-aware scale-down guard (see

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -507,10 +507,10 @@ class Autoscaler:
         Args:
             pools: Actor pools to update with the new scaling results.
             upstream_queue_lens: Per-stage upstream queue lengths. Entry
-                ``[i]`` is the number of tasks waiting to be pulled into
-                ``pools[i]`` (the pipeline's input queue for stage ``0``, or
-                ``queues[i - 1]`` for downstream stages). Must have the same
-                length as ``pools``.
+                ``[i]`` is the number of queued samples/items waiting to be
+                pulled into ``pools[i]`` (the pipeline's input queue for
+                stage ``0``, or ``queues[i - 1]`` for downstream stages).
+                Must have the same length as ``pools``.
             stage_batch_sizes: Per-stage declared ``stage_batch_size`` values
                 (each must be ``>= 1``). Must have the same length as
                 ``pools``.

--- a/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
+++ b/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
@@ -23,7 +23,7 @@ import concurrent.futures
 import logging
 import math
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -55,8 +55,8 @@ def _make_mock_pool(
 
 def _make_solution_stage(
     *,
-    new_workers: list[Any] | None = None,
-    deleted_workers: list[Any] | None = None,
+    new_workers: Optional[list[Any]] = None,
+    deleted_workers: Optional[list[Any]] = None,
     slots_per_worker: int = 1,
 ) -> MagicMock:
     """Build a mock ``StageSolution`` matching what Rust would return."""

--- a/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
+++ b/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
@@ -22,8 +22,9 @@ CPU-only tests for ``_required_workers_for_stage`` (algorithmic core) and
 import concurrent.futures
 import logging
 import math
+import time
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -55,8 +56,8 @@ def _make_mock_pool(
 
 def _make_solution_stage(
     *,
-    new_workers: Optional[list[Any]] = None,
-    deleted_workers: Optional[list[Any]] = None,
+    new_workers: list[Any] | None = None,
+    deleted_workers: list[Any] | None = None,
     slots_per_worker: int = 1,
 ) -> MagicMock:
     """Build a mock ``StageSolution`` matching what Rust would return."""
@@ -99,7 +100,10 @@ def _make_autoscaler_with_solution(solution: MagicMock, enable_backlog_guard: bo
     future: concurrent.futures.Future[MagicMock] = concurrent.futures.Future()
     future.set_result(solution)
     autoscaler._autoscale_future = future
-    autoscaler._autoscale_start_time = 0.0
+    # Use a recent timestamp so the ``elapsed > 1.0s`` warning in
+    # ``apply_autoscale_result_if_ready`` does not fire for unit tests
+    # (a literal ``0.0`` would yield ``time.time() - 0.0`` >> 1.0s).
+    autoscaler._autoscale_start_time = time.time()
     autoscaler._enable_backlog_guard = enable_backlog_guard
     return autoscaler
 
@@ -194,6 +198,7 @@ def test_blocks_deletions_when_backlog_exists() -> None:
         pools=[pool],
         upstream_queue_lens=[0],
         stage_batch_sizes=[1],
+        stages_is_dones=[False],
     )
 
     assert pool.add_actor_to_delete.call_count == 2
@@ -216,6 +221,7 @@ def test_allows_deletions_when_no_backlog_no_inflight() -> None:
         pools=[pool],
         upstream_queue_lens=[0],
         stage_batch_sizes=[1],
+        stages_is_dones=[False],
     )
 
     # 20 actors, required floor = MIN_WORKERS_PER_STAGE = 1, so deletions capped at 19.
@@ -247,6 +253,7 @@ def test_enforces_min_workers_floor_on_drain_tail() -> None:
         pools=[pool],
         upstream_queue_lens=[0],
         stage_batch_sizes=[1],
+        stages_is_dones=[False],
     )
 
     assert pool.add_actor_to_delete.call_count == 2 - Autoscaler.MIN_WORKERS_PER_STAGE
@@ -269,6 +276,7 @@ def test_preserves_workers_for_inflight_only() -> None:
         pools=[pool],
         upstream_queue_lens=[0],
         stage_batch_sizes=[1],
+        stages_is_dones=[False],
     )
 
     assert pool.add_actor_to_delete.call_count == 6
@@ -291,6 +299,7 @@ def test_preserves_workers_for_upstream_backlog() -> None:
         pools=[pool],
         upstream_queue_lens=[20],
         stage_batch_sizes=[1],
+        stages_is_dones=[False],
     )
 
     assert pool.add_actor_to_delete.call_count == 0
@@ -312,6 +321,7 @@ def test_does_not_amplify_rust_proposal() -> None:
         pools=[pool],
         upstream_queue_lens=[0],
         stage_batch_sizes=[1],
+        stages_is_dones=[False],
     )
 
     assert pool.add_actor_to_delete.call_count == 3
@@ -333,6 +343,7 @@ def test_first_stage_uses_input_queue_length() -> None:
         pools=[pool],
         upstream_queue_lens=[5],
         stage_batch_sizes=[1],
+        stages_is_dones=[False],
     )
 
     assert pool.add_actor_to_delete.call_count == 0
@@ -368,6 +379,7 @@ def test_non_first_stage_uses_its_own_upstream_queue_entry() -> None:
         pools=[pool0, pool1],
         upstream_queue_lens=[0, 5],
         stage_batch_sizes=[1, 1],
+        stages_is_dones=[False, False],
     )
 
     assert pool0.add_actor_to_delete.call_count == 4
@@ -416,6 +428,7 @@ def test_logs_clamping_at_info_level(loguru_caplog: pytest.LogCaptureFixture) ->
         pools=[pool],
         upstream_queue_lens=[0],
         stage_batch_sizes=[1],
+        stages_is_dones=[False],
     )
 
     clamp_messages = [rec.getMessage() for rec in loguru_caplog.records if "Clamped scale-down" in rec.getMessage()]
@@ -443,41 +456,36 @@ def test_logs_clamping_at_info_level(loguru_caplog: pytest.LogCaptureFixture) ->
         "expect_clamp_log",
     ),
     [
-        # ----- Scenario 1: heavy upstream backlog -----
-        # backlog=20, slots=2, batch=1 -> required = ceil(20/2) = 10 workers
-        # ready=10 -> max_safe = 0; guard refuses all 5 deletions
-        # disabled bypasses entirely -> all 5 pass through
+        # Heavy upstream backlog: backlog=20, slots=2, batch=1
+        # -> required = ceil(20/2) = 10; ready=10 -> max_safe = 0
+        # Guard refuses all 5 deletions; disabled bypasses entirely.
         pytest.param(10, 2, 1, 0, 0, 20, 5, True, 0, True, id="heavy_upstream_backlog_guard_on"),
         pytest.param(10, 2, 1, 0, 0, 20, 5, False, 5, False, id="heavy_upstream_backlog_guard_off"),
-        # ----- Scenario 2: pool's own queue backlog (same arithmetic) -----
-        # Confirms the guard sums upstream_q AND pool's num_queued_tasks
+        # Pool's own queue backlog (same arithmetic) confirms the guard
+        # sums upstream_q AND pool's num_queued_tasks.
         pytest.param(10, 2, 1, 0, 20, 0, 5, True, 0, True, id="pool_queue_backlog_guard_on"),
         pytest.param(10, 2, 1, 0, 20, 0, 5, False, 5, False, id="pool_queue_backlog_guard_off"),
-        # ----- Scenario 3: in-flight dominates the floor -----
-        # inflight=8, slots=2 -> required = ceil(8/2) = 4
-        # ready=10, max_safe = 6; proposed=9 -> allowed=min(9,6)=6
-        # disabled passes all 9 through (does NOT preserve in-flight slots)
+        # In-flight dominates the floor: inflight=8, slots=2 -> required = 4.
+        # ready=10, max_safe=6, proposed=9 -> allowed=6. Disabled passes all
+        # 9 through (does NOT preserve in-flight slots).
         pytest.param(10, 2, 1, 8, 0, 0, 9, True, 6, True, id="inflight_dominates_guard_on"),
         pytest.param(10, 2, 1, 8, 0, 0, 9, False, 9, False, id="inflight_dominates_guard_off"),
-        # ----- Scenario 4: drain-tail with no work -----
-        # required = max(MIN_WORKERS_PER_STAGE=1, 0, 0) = 1
-        # ready=5, max_safe=4; proposed=5 -> guard keeps 1 alive (allows 4)
-        # disabled allows all 5 (no floor protection at all)
+        # Drain-tail with no work: required = MIN_WORKERS_PER_STAGE = 1.
+        # ready=5, max_safe=4, proposed=5 -> guard keeps 1 alive (allows 4).
+        # Disabled allows all 5 (no floor protection at all).
         pytest.param(5, 1, 1, 0, 0, 0, 5, True, 4, True, id="drain_tail_guard_on"),
         pytest.param(5, 1, 1, 0, 0, 0, 5, False, 5, False, id="drain_tail_guard_off"),
-        # ----- Scenario 5: mixed in-flight + backlog -----
-        # inflight=4 -> w_inflight = 2; backlog=10, slots=2, batch=1 -> w_backlog = 5
-        # required = max(1, 2, 5) = 5; ready=8, max_safe=3; proposed=6 -> allowed=3
+        # Mixed in-flight + backlog: inflight=4 -> w_inflight=2;
+        # backlog=10, slots=2, batch=1 -> w_backlog=5; required = max(1,2,5) = 5.
+        # ready=8, max_safe=3, proposed=6 -> allowed=3.
         pytest.param(8, 2, 1, 4, 10, 0, 6, True, 3, True, id="inflight_plus_backlog_guard_on"),
         pytest.param(8, 2, 1, 4, 10, 0, 6, False, 6, False, id="inflight_plus_backlog_guard_off"),
-        # ----- Scenario 6: partial clamping (Rust proposal exceeds safe budget) -----
-        # backlog=6, slots=2, batch=1 -> required = ceil(6/2) = 3
-        # ready=10, max_safe=7; proposed=8 -> allowed=7 (one held back)
-        # disabled passes all 8 through -- single-deletion difference still
-        # produces the clamp log under guard=True.
+        # Partial clamping: backlog=6, slots=2, batch=1 -> required=3.
+        # ready=10, max_safe=7, proposed=8 -> allowed=7 (one held back).
+        # Single-deletion difference still produces the clamp log under guard=True.
         pytest.param(10, 2, 1, 0, 0, 6, 8, True, 7, True, id="partial_clamp_guard_on"),
         pytest.param(10, 2, 1, 0, 0, 6, 8, False, 8, False, id="partial_clamp_guard_off"),
-        # ----- Scenario 7: no work AND no clamping needed -----
+        # No work AND no clamping needed:
         # required = MIN_WORKERS_PER_STAGE = 1; ready=20, proposed=3
         # max_safe=19, allowed=min(3,19)=3 -- guard still permits all 3.
         # No clamping happens, so no log line under guard=True either.
@@ -521,6 +529,7 @@ def test_guard_flag_governs_deletion_clamping(
         pools=[pool],
         upstream_queue_lens=[upstream_q],
         stage_batch_sizes=[stage_batch_size],
+        stages_is_dones=[False],
     )
 
     assert pool.add_actor_to_delete.call_count == expected_deletions, (
@@ -539,7 +548,7 @@ def test_no_future_does_nothing() -> None:
     """Method is a safe no-op when no autoscale future is pending."""
     autoscaler = object.__new__(Autoscaler)
     autoscaler._autoscale_future = None
-    autoscaler._autoscale_start_time = 0.0
+    autoscaler._autoscale_start_time = time.time()
 
     pool = _make_mock_pool(
         num_ready_actors=5,
@@ -552,7 +561,52 @@ def test_no_future_does_nothing() -> None:
         pools=[pool],
         upstream_queue_lens=[0],
         stage_batch_sizes=[1],
+        stages_is_dones=[False],
     )
 
     assert pool.add_actor_to_delete.call_count == 0
     assert pool.add_actor_to_create.call_count == 0
+
+
+def test_finished_stage_bypasses_floor_to_release_workers() -> None:
+    """Finished stages skip the guard so end-of-stage teardown can release actors.
+
+    When ``stages_is_dones[idx]`` is ``True`` the guard must not enforce
+    ``MIN_WORKERS_PER_STAGE``: the stage will be torn down by ``run_pipeline``
+    on the same iteration via ``pool.stop()``, and Rust's proposed full
+    deletion must reach ``ActorPool`` so the resources are freed promptly.
+    """
+    pool = _make_mock_pool(
+        name="FinishedStage",
+        num_ready_actors=5,
+        num_used_slots=0,
+        slots_per_actor=1,
+        num_queued_tasks=0,
+    )
+    solution = _make_solution([_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(5)])])
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[0],
+        stage_batch_sizes=[1],
+        stages_is_dones=[True],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 5
+
+
+def test_raises_on_mismatched_solution_stage_count() -> None:
+    """Planner contract: ``autoscale_result.stages`` length must match ``pools``."""
+    pool = _make_mock_pool(num_ready_actors=1, num_used_slots=0, slots_per_actor=1, num_queued_tasks=0)
+    # Solution has two stages, but caller passes only one pool.
+    solution = _make_solution([_make_solution_stage(), _make_solution_stage()])
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    with pytest.raises(ValueError, match="planner contract violated"):
+        autoscaler.apply_autoscale_result_if_ready(
+            pools=[pool],
+            upstream_queue_lens=[0],
+            stage_batch_sizes=[1],
+            stages_is_dones=[False],
+        )

--- a/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
+++ b/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
@@ -24,7 +24,7 @@ import logging
 import math
 import time
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -56,8 +56,8 @@ def _make_mock_pool(
 
 def _make_solution_stage(
     *,
-    new_workers: list[Any] | None = None,
-    deleted_workers: list[Any] | None = None,
+    new_workers: Optional[list[Any]] = None,
+    deleted_workers: Optional[list[Any]] = None,
     slots_per_worker: int = 1,
 ) -> MagicMock:
     """Build a mock ``StageSolution`` matching what Rust would return."""

--- a/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
+++ b/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
@@ -327,6 +327,67 @@ def test_does_not_amplify_rust_proposal() -> None:
     assert pool.add_actor_to_delete.call_count == 3
 
 
+def test_pool_queue_units_are_tasks_not_samples_under_batch_gt_one() -> None:
+    """Pool's ``num_queued_tasks`` is sample-normalized when ``stage_batch_size > 1``.
+
+    Each entry in ``ActorPool._task_queue`` is a pre-batched ``Task``, but
+    ``Queue.__len__`` (upstream) counts individual sample ``ObjectRef``s.
+    The guard's call site must multiply the pool count by ``stage_batch_size``
+    before summing, otherwise the pool contribution is undercounted by a
+    factor of ``stage_batch_size`` and the guard authorises too many
+    deletions during drain-tail.
+    """
+    # ready=10, slots=1, batch=4, num_queued_tasks=4, upstream_q=0
+    #   buggy: backlog_samples = 0 + 4   = 4  -> required = ceil(4 /4) = 1 -> max_safe = 9
+    #   fixed: backlog_samples = 0 + 4*4 = 16 -> required = ceil(16/4) = 4 -> max_safe = 6
+    pool = _make_mock_pool(
+        num_ready_actors=10,
+        num_used_slots=0,
+        slots_per_actor=1,
+        num_queued_tasks=4,
+    )
+    solution = _make_solution([_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(9)])])
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[0],
+        stage_batch_sizes=[4],
+        stages_is_dones=[False],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 6
+
+
+def test_mixed_upstream_samples_and_pool_tasks_with_batch_gt_one() -> None:
+    """Both queues contribute when ``batch > 1``; their drain demand sums in samples.
+
+    With non-zero upstream samples AND non-zero pool tasks, the buggy formula
+    silently undercounts the pool contribution. The chosen tuple makes the
+    divergence observable: fixed allows 6 deletions, buggy allows 7.
+    """
+    # ready=8, slots=2, batch=4, num_queued_tasks=3, upstream_q=4
+    #   buggy: backlog_samples = 4 + 3   = 7  -> required = ceil(7 /(2*4)) = 1 -> max_safe = 7
+    #   fixed: backlog_samples = 4 + 3*4 = 16 -> required = ceil(16/(2*4)) = 2 -> max_safe = 6
+    pool = _make_mock_pool(
+        num_ready_actors=8,
+        num_used_slots=0,
+        slots_per_actor=2,
+        num_queued_tasks=3,
+    )
+    solution = _make_solution([_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(7)])])
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[4],
+        stage_batch_sizes=[4],
+        stages_is_dones=[False],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 6
+
+
 def test_first_stage_uses_input_queue_length() -> None:
     """Stage index 0 reads ``upstream_queue_lens[0]`` (the pipeline input queue)."""
     pool = _make_mock_pool(
@@ -491,6 +552,12 @@ def test_logs_clamping_at_info_level(loguru_caplog: pytest.LogCaptureFixture) ->
         # No clamping happens, so no log line under guard=True either.
         pytest.param(20, 2, 1, 0, 0, 0, 3, True, 3, False, id="no_clamp_needed_guard_on"),
         pytest.param(20, 2, 1, 0, 0, 0, 3, False, 3, False, id="no_clamp_needed_guard_off"),
+        # Pool queue with batch>1 (locks the unit-conversion fix into the matrix):
+        # ready=10, slots=1, batch=4, queued_tasks=4 -> backlog_samples = 4*4 = 16,
+        # required = ceil(16/(1*4)) = 4, max_safe = 6, proposed=9 -> allowed=6.
+        # Disabled bypass authorises all 9 deletions.
+        pytest.param(10, 1, 4, 0, 4, 0, 9, True, 6, True, id="pool_queue_batch_gt_one_guard_on"),
+        pytest.param(10, 1, 4, 0, 4, 0, 9, False, 9, False, id="pool_queue_batch_gt_one_guard_off"),
     ],
 )
 def test_guard_flag_governs_deletion_clamping(

--- a/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
+++ b/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
@@ -1,0 +1,439 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the backlog-aware scale-down guard.
+
+CPU-only tests for ``_required_workers_for_stage`` (algorithmic core) and
+``Autoscaler.apply_autoscale_result_if_ready`` (deletion clamping).
+"""
+
+import concurrent.futures
+import logging
+import math
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from loguru import logger as loguru_logger
+
+from cosmos_xenna.pipelines.private.streaming import (
+    Autoscaler,
+    _required_workers_for_stage,
+)
+
+
+def _make_mock_pool(
+    *,
+    name: str = "stage",
+    num_ready_actors: int,
+    num_used_slots: int,
+    slots_per_actor: int,
+    num_queued_tasks: int,
+) -> MagicMock:
+    """Build a lightweight mock ActorPool exposing only what the guard reads."""
+    pool = MagicMock(name=f"pool-{name}")
+    pool.name = name
+    pool.num_ready_actors = num_ready_actors
+    pool.num_used_slots = num_used_slots
+    pool.slots_per_actor = slots_per_actor
+    pool.num_queued_tasks = num_queued_tasks
+    return pool
+
+
+def _make_solution_stage(
+    *,
+    new_workers: list[Any] | None = None,
+    deleted_workers: list[Any] | None = None,
+    slots_per_worker: int = 1,
+) -> MagicMock:
+    """Build a mock ``StageSolution`` matching what Rust would return."""
+    stage = MagicMock(name="stage-solution")
+    stage.new_workers = new_workers or []
+    stage.deleted_workers = deleted_workers or []
+    stage.slots_per_worker = slots_per_worker
+    return stage
+
+
+def _make_solution(stage_solutions: list[MagicMock]) -> MagicMock:
+    """Build a mock ``Solution`` object with the given stage solutions."""
+    solution = MagicMock(name="solution")
+    solution.stages = stage_solutions
+    return solution
+
+
+def _make_deleted_worker(worker_id: str = "w") -> MagicMock:
+    """Build a mock ``ProblemWorkerGroupState`` suitable for deletion tracking."""
+    w = MagicMock(name=f"deleted-{worker_id}")
+    w.to_worker_group.return_value = MagicMock(name=f"worker-group-{worker_id}")
+    return w
+
+
+def _make_autoscaler_with_solution(solution: MagicMock) -> Autoscaler:
+    """Construct an ``Autoscaler`` bypassing ``__init__`` and pre-loaded solution."""
+    autoscaler = object.__new__(Autoscaler)
+    future: concurrent.futures.Future[MagicMock] = concurrent.futures.Future()
+    future.set_result(solution)
+    autoscaler._autoscale_future = future
+    autoscaler._autoscale_start_time = 0.0
+    return autoscaler
+
+
+def test_helper_floor_when_no_inflight_no_backlog() -> None:
+    """Return MIN_WORKERS_PER_STAGE when nothing is in-flight and nothing is queued."""
+    required = _required_workers_for_stage(
+        slots_per_actor=4,
+        stage_batch_size=1,
+        inflight_slots=0,
+        backlog_samples=0,
+    )
+    assert required == Autoscaler.MIN_WORKERS_PER_STAGE
+
+
+def test_helper_uses_max_of_inflight_and_backlog() -> None:
+    """Pick max(workers_for_inflight, workers_for_backlog) when both apply."""
+    # slots_per_actor=2, batch=1 -> capacity_per_actor=2
+    # inflight=4  -> workers_for_inflight = ceil(4/2) = 2
+    # backlog=12  -> workers_for_backlog  = ceil(12/2) = 6
+    required = _required_workers_for_stage(
+        slots_per_actor=2,
+        stage_batch_size=1,
+        inflight_slots=4,
+        backlog_samples=12,
+    )
+    assert required == 6
+
+
+def test_helper_inflight_only_path() -> None:
+    """With no backlog, required workers == ceil(inflight/slots_per_actor)."""
+    required = _required_workers_for_stage(
+        slots_per_actor=3,
+        stage_batch_size=4,
+        inflight_slots=7,
+        backlog_samples=0,
+    )
+    assert required == math.ceil(7 / 3)
+
+
+def test_helper_backlog_only_path() -> None:
+    """With no in-flight work, required workers == ceil(backlog/capacity_per_actor)."""
+    # capacity_per_actor = slots_per_actor * batch = 2 * 4 = 8
+    required = _required_workers_for_stage(
+        slots_per_actor=2,
+        stage_batch_size=4,
+        inflight_slots=0,
+        backlog_samples=20,
+    )
+    assert required == math.ceil(20 / 8)
+
+
+def test_helper_raises_on_zero_slots_per_actor() -> None:
+    """Invalid slots_per_actor triggers ValueError, never a ZeroDivisionError."""
+    with pytest.raises(ValueError, match="slots_per_actor"):
+        _required_workers_for_stage(
+            slots_per_actor=0,
+            stage_batch_size=1,
+            inflight_slots=0,
+            backlog_samples=0,
+        )
+
+
+def test_helper_raises_on_zero_stage_batch_size() -> None:
+    """Invalid stage_batch_size triggers ValueError, never a ZeroDivisionError."""
+    with pytest.raises(ValueError, match="stage_batch_size"):
+        _required_workers_for_stage(
+            slots_per_actor=1,
+            stage_batch_size=0,
+            inflight_slots=0,
+            backlog_samples=0,
+        )
+
+
+def test_blocks_deletions_when_backlog_exists() -> None:
+    """Clamp deletions when the pool has a heavy backlog."""
+    # 20 actors, 2 slots each, pool_q=36, no in-flight -> required = ceil(36/2)=18
+    # max_safe_deletions = 20-18=2
+    pool = _make_mock_pool(
+        name="VideoFrameExtractionStage",
+        num_ready_actors=20,
+        num_used_slots=0,
+        slots_per_actor=2,
+        num_queued_tasks=36,
+    )
+    solution = _make_solution(
+        [_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(18)])]
+    )
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[0],
+        stage_batch_sizes=[1],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 2
+
+
+def test_allows_deletions_when_no_backlog_no_inflight() -> None:
+    """When there is nothing to protect, all proposed deletions pass through."""
+    pool = _make_mock_pool(
+        num_ready_actors=20,
+        num_used_slots=0,
+        slots_per_actor=2,
+        num_queued_tasks=0,
+    )
+    solution = _make_solution(
+        [_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(18)])]
+    )
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[0],
+        stage_batch_sizes=[1],
+    )
+
+    # 20 actors, required floor = MIN_WORKERS_PER_STAGE = 1, so deletions capped at 19.
+    assert pool.add_actor_to_delete.call_count == min(18, 20 - Autoscaler.MIN_WORKERS_PER_STAGE)
+
+
+def test_enforces_min_workers_floor_on_drain_tail() -> None:
+    """Guard keeps MIN_WORKERS_PER_STAGE actors alive even when Rust proposes full deletion.
+
+    Drain-tail scenario: upstream has gone silent, the pool's queue is empty, and
+    nothing is in flight, so Rust (throughput-blind) proposes deleting every
+    remaining actor. Fully applying that proposal would cost an autoscaler cycle
+    to cold-start a worker when fresh work finally arrives. The guard must leave
+    ``MIN_WORKERS_PER_STAGE`` workers alive on the active-stage path; actual
+    end-of-pipeline teardown happens via the pipeline context exit, not here.
+    """
+    # current=2, required = max(MIN_WORKERS_PER_STAGE=1, 0, 0) = 1
+    # max_safe = max(0, 2 - 1) = 1; Rust proposed 2 -> allowed = 1.
+    pool = _make_mock_pool(
+        num_ready_actors=2,
+        num_used_slots=0,
+        slots_per_actor=1,
+        num_queued_tasks=0,
+    )
+    solution = _make_solution([_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(2)])])
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[0],
+        stage_batch_sizes=[1],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 2 - Autoscaler.MIN_WORKERS_PER_STAGE
+
+
+def test_preserves_workers_for_inflight_only() -> None:
+    """In-flight slots dominate the floor when there is no queued backlog."""
+    # slots_per_actor=2, inflight=8 -> required = ceil(8/2) = 4
+    # current=10 -> max_safe = 6
+    pool = _make_mock_pool(
+        num_ready_actors=10,
+        num_used_slots=8,
+        slots_per_actor=2,
+        num_queued_tasks=0,
+    )
+    solution = _make_solution([_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(9)])])
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[0],
+        stage_batch_sizes=[1],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 6
+
+
+def test_preserves_workers_for_upstream_backlog() -> None:
+    """Upstream queue backlog counts the same as the pool's own queue backlog."""
+    # slots_per_actor=2, batch=1, capacity=2, upstream=20, pool_q=0 -> required=ceil(20/2)=10
+    # current=10 -> max_safe = 0
+    pool = _make_mock_pool(
+        num_ready_actors=10,
+        num_used_slots=0,
+        slots_per_actor=2,
+        num_queued_tasks=0,
+    )
+    solution = _make_solution([_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(5)])])
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[20],
+        stage_batch_sizes=[1],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 0
+
+
+def test_does_not_amplify_rust_proposal() -> None:
+    """Guard never deletes more workers than Rust proposed."""
+    # max_safe_deletions = 10-1 = 9, but Rust only proposed 3 -> applied=3
+    pool = _make_mock_pool(
+        num_ready_actors=10,
+        num_used_slots=0,
+        slots_per_actor=2,
+        num_queued_tasks=0,
+    )
+    solution = _make_solution([_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(3)])])
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[0],
+        stage_batch_sizes=[1],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 3
+
+
+def test_first_stage_uses_input_queue_length() -> None:
+    """Stage index 0 reads ``upstream_queue_lens[0]`` (the pipeline input queue)."""
+    pool = _make_mock_pool(
+        num_ready_actors=5,
+        num_used_slots=0,
+        slots_per_actor=1,
+        num_queued_tasks=0,
+    )
+    solution = _make_solution([_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(4)])])
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    # upstream=5 tasks, batch=1, slots=1 -> capacity=1 -> required=5 -> max_safe=0
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[5],
+        stage_batch_sizes=[1],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 0
+
+
+def test_non_first_stage_uses_its_own_upstream_queue_entry() -> None:
+    """Stage index 1 reads ``upstream_queue_lens[1]`` (not stage 0's entry)."""
+    pool0 = _make_mock_pool(
+        name="s0",
+        num_ready_actors=5,
+        num_used_slots=0,
+        slots_per_actor=1,
+        num_queued_tasks=0,
+    )
+    pool1 = _make_mock_pool(
+        name="s1",
+        num_ready_actors=5,
+        num_used_slots=0,
+        slots_per_actor=1,
+        num_queued_tasks=0,
+    )
+    solution = _make_solution(
+        [
+            _make_solution_stage(deleted_workers=[_make_deleted_worker(f"s0-w{i}") for i in range(4)]),
+            _make_solution_stage(deleted_workers=[_make_deleted_worker(f"s1-w{i}") for i in range(4)]),
+        ]
+    )
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    # Stage 0 has no upstream backlog (=0) -> allowed to scale down to floor.
+    # Stage 1 sees 5 tasks in its upstream -> required=5 -> max_safe=0.
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool0, pool1],
+        upstream_queue_lens=[0, 5],
+        stage_batch_sizes=[1, 1],
+    )
+
+    assert pool0.add_actor_to_delete.call_count == 4
+    assert pool1.add_actor_to_delete.call_count == 0
+
+
+@pytest.fixture
+def loguru_caplog(caplog: pytest.LogCaptureFixture) -> Iterator[pytest.LogCaptureFixture]:
+    """Bridge loguru records into pytest's stdlib-based ``caplog`` fixture.
+
+    ``cosmos_xenna.utils.python_log`` routes logging through loguru, which does
+    not propagate to the stdlib ``logging`` module by default, so ``caplog`` is
+    otherwise blind to ``logger.info(...)`` calls. The bridge re-emits every
+    loguru record through a stdlib logger named ``"loguru"``. The sink is torn
+    down automatically at the end of the test.
+    """
+    handler_id = loguru_logger.add(
+        lambda msg: logging.getLogger("loguru").log(msg.record["level"].no, msg.record["message"]),
+        level=0,
+        format="{message}",
+    )
+    caplog.set_level(logging.DEBUG, logger="loguru")
+    try:
+        yield caplog
+    finally:
+        loguru_logger.remove(handler_id)
+
+
+def test_logs_clamping_at_info_level(loguru_caplog: pytest.LogCaptureFixture) -> None:
+    """INFO log is emitted with stage name + counts when the guard clamps deletions."""
+    # num_queued=20, slots=1, batch=1 -> required = max(1, 0, ceil(20/1)) = 20
+    # current=13, required=20 -> max_safe = max(0, 13-20) = 0, so allowed = 0.
+    pool = _make_mock_pool(
+        name="ClipTranscodingStage",
+        num_ready_actors=13,
+        num_used_slots=0,
+        slots_per_actor=1,
+        num_queued_tasks=20,
+    )
+    solution = _make_solution(
+        [_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(11)])]
+    )
+    autoscaler = _make_autoscaler_with_solution(solution)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[0],
+        stage_batch_sizes=[1],
+    )
+
+    clamp_messages = [rec.getMessage() for rec in loguru_caplog.records if "Clamped scale-down" in rec.getMessage()]
+    assert len(clamp_messages) == 1
+    message = clamp_messages[0]
+    assert "ClipTranscodingStage" in message
+    assert "current=13" in message
+    assert "required=20" in message
+    assert "proposed_delete=11" in message
+    assert "allowed_delete=0" in message
+    assert "pool_q=20" in message
+
+
+def test_no_future_does_nothing() -> None:
+    """Method is a safe no-op when no autoscale future is pending."""
+    autoscaler = object.__new__(Autoscaler)
+    autoscaler._autoscale_future = None
+    autoscaler._autoscale_start_time = 0.0
+
+    pool = _make_mock_pool(
+        num_ready_actors=5,
+        num_used_slots=0,
+        slots_per_actor=1,
+        num_queued_tasks=0,
+    )
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[0],
+        stage_batch_sizes=[1],
+    )
+
+    assert pool.add_actor_to_delete.call_count == 0
+    assert pool.add_actor_to_create.call_count == 0

--- a/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
+++ b/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
@@ -328,7 +328,7 @@ def test_does_not_amplify_rust_proposal() -> None:
 
 
 def test_pool_queue_units_are_tasks_not_samples_under_batch_gt_one() -> None:
-    """Pool's ``num_queued_tasks`` is sample-normalized when ``stage_batch_size > 1``.
+    """Pool's ``num_queued_tasks`` must be sample-normalized when ``stage_batch_size > 1``.
 
     Each entry in ``ActorPool._task_queue`` is a pre-batched ``Task``, but
     ``Queue.__len__`` (upstream) counts individual sample ``ObjectRef``s.

--- a/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
+++ b/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
@@ -81,13 +81,26 @@ def _make_deleted_worker(worker_id: str = "w") -> MagicMock:
     return w
 
 
-def _make_autoscaler_with_solution(solution: MagicMock) -> Autoscaler:
-    """Construct an ``Autoscaler`` bypassing ``__init__`` and pre-loaded solution."""
+def _make_autoscaler_with_solution(solution: MagicMock, enable_backlog_guard: bool = True) -> Autoscaler:
+    """Construct an ``Autoscaler`` bypassing ``__init__`` with a pre-loaded solution.
+
+    Args:
+        solution: Mock ``Solution`` returned by ``self._autoscale_future.result()``.
+        enable_backlog_guard: Value for ``Autoscaler._enable_backlog_guard``.
+            Defaults to ``True`` so existing tests continue to exercise the
+            active-guard path. Set to ``False`` to verify the disabled path.
+
+    Returns:
+        An ``Autoscaler`` instance with the minimal attributes required by
+        ``apply_autoscale_result_if_ready``.
+
+    """
     autoscaler = object.__new__(Autoscaler)
     future: concurrent.futures.Future[MagicMock] = concurrent.futures.Future()
     future.set_result(solution)
     autoscaler._autoscale_future = future
     autoscaler._autoscale_start_time = 0.0
+    autoscaler._enable_backlog_guard = enable_backlog_guard
     return autoscaler
 
 
@@ -414,6 +427,112 @@ def test_logs_clamping_at_info_level(loguru_caplog: pytest.LogCaptureFixture) ->
     assert "proposed_delete=11" in message
     assert "allowed_delete=0" in message
     assert "pool_q=20" in message
+
+
+@pytest.mark.parametrize(
+    (
+        "ready_actors",
+        "slots_per_actor",
+        "stage_batch_size",
+        "inflight_slots",
+        "queued_tasks",
+        "upstream_q",
+        "proposed_deletions",
+        "enable_guard",
+        "expected_deletions",
+        "expect_clamp_log",
+    ),
+    [
+        # ----- Scenario 1: heavy upstream backlog -----
+        # backlog=20, slots=2, batch=1 -> required = ceil(20/2) = 10 workers
+        # ready=10 -> max_safe = 0; guard refuses all 5 deletions
+        # disabled bypasses entirely -> all 5 pass through
+        pytest.param(10, 2, 1, 0, 0, 20, 5, True, 0, True, id="heavy_upstream_backlog_guard_on"),
+        pytest.param(10, 2, 1, 0, 0, 20, 5, False, 5, False, id="heavy_upstream_backlog_guard_off"),
+        # ----- Scenario 2: pool's own queue backlog (same arithmetic) -----
+        # Confirms the guard sums upstream_q AND pool's num_queued_tasks
+        pytest.param(10, 2, 1, 0, 20, 0, 5, True, 0, True, id="pool_queue_backlog_guard_on"),
+        pytest.param(10, 2, 1, 0, 20, 0, 5, False, 5, False, id="pool_queue_backlog_guard_off"),
+        # ----- Scenario 3: in-flight dominates the floor -----
+        # inflight=8, slots=2 -> required = ceil(8/2) = 4
+        # ready=10, max_safe = 6; proposed=9 -> allowed=min(9,6)=6
+        # disabled passes all 9 through (does NOT preserve in-flight slots)
+        pytest.param(10, 2, 1, 8, 0, 0, 9, True, 6, True, id="inflight_dominates_guard_on"),
+        pytest.param(10, 2, 1, 8, 0, 0, 9, False, 9, False, id="inflight_dominates_guard_off"),
+        # ----- Scenario 4: drain-tail with no work -----
+        # required = max(MIN_WORKERS_PER_STAGE=1, 0, 0) = 1
+        # ready=5, max_safe=4; proposed=5 -> guard keeps 1 alive (allows 4)
+        # disabled allows all 5 (no floor protection at all)
+        pytest.param(5, 1, 1, 0, 0, 0, 5, True, 4, True, id="drain_tail_guard_on"),
+        pytest.param(5, 1, 1, 0, 0, 0, 5, False, 5, False, id="drain_tail_guard_off"),
+        # ----- Scenario 5: mixed in-flight + backlog -----
+        # inflight=4 -> w_inflight = 2; backlog=10, slots=2, batch=1 -> w_backlog = 5
+        # required = max(1, 2, 5) = 5; ready=8, max_safe=3; proposed=6 -> allowed=3
+        pytest.param(8, 2, 1, 4, 10, 0, 6, True, 3, True, id="inflight_plus_backlog_guard_on"),
+        pytest.param(8, 2, 1, 4, 10, 0, 6, False, 6, False, id="inflight_plus_backlog_guard_off"),
+        # ----- Scenario 6: partial clamping (Rust proposal exceeds safe budget) -----
+        # backlog=6, slots=2, batch=1 -> required = ceil(6/2) = 3
+        # ready=10, max_safe=7; proposed=8 -> allowed=7 (one held back)
+        # disabled passes all 8 through -- single-deletion difference still
+        # produces the clamp log under guard=True.
+        pytest.param(10, 2, 1, 0, 0, 6, 8, True, 7, True, id="partial_clamp_guard_on"),
+        pytest.param(10, 2, 1, 0, 0, 6, 8, False, 8, False, id="partial_clamp_guard_off"),
+        # ----- Scenario 7: no work AND no clamping needed -----
+        # required = MIN_WORKERS_PER_STAGE = 1; ready=20, proposed=3
+        # max_safe=19, allowed=min(3,19)=3 -- guard still permits all 3.
+        # No clamping happens, so no log line under guard=True either.
+        pytest.param(20, 2, 1, 0, 0, 0, 3, True, 3, False, id="no_clamp_needed_guard_on"),
+        pytest.param(20, 2, 1, 0, 0, 0, 3, False, 3, False, id="no_clamp_needed_guard_off"),
+    ],
+)
+def test_guard_flag_governs_deletion_clamping(
+    loguru_caplog: pytest.LogCaptureFixture,
+    ready_actors: int,
+    slots_per_actor: int,
+    stage_batch_size: int,
+    inflight_slots: int,
+    queued_tasks: int,
+    upstream_q: int,
+    proposed_deletions: int,
+    enable_guard: bool,
+    expected_deletions: int,
+    expect_clamp_log: bool,
+) -> None:
+    """Verify ``apply_autoscale_result_if_ready`` honours ``_enable_backlog_guard``.
+
+    Each parameter row captures one (pool state, Rust proposal, guard flag)
+    combination, alongside the expected number of accepted deletions and
+    whether a ``Clamped scale-down`` INFO log must be emitted. Pairs with
+    matching ``..._on`` / ``..._off`` ids prove the flag flips behavior
+    while holding all other inputs constant.
+    """
+    pool = _make_mock_pool(
+        num_ready_actors=ready_actors,
+        num_used_slots=inflight_slots,
+        slots_per_actor=slots_per_actor,
+        num_queued_tasks=queued_tasks,
+    )
+    solution = _make_solution(
+        [_make_solution_stage(deleted_workers=[_make_deleted_worker(f"w{i}") for i in range(proposed_deletions)])]
+    )
+    autoscaler = _make_autoscaler_with_solution(solution, enable_backlog_guard=enable_guard)
+
+    autoscaler.apply_autoscale_result_if_ready(
+        pools=[pool],
+        upstream_queue_lens=[upstream_q],
+        stage_batch_sizes=[stage_batch_size],
+    )
+
+    assert pool.add_actor_to_delete.call_count == expected_deletions, (
+        f"deletion count mismatch: expected {expected_deletions}, got {pool.add_actor_to_delete.call_count}"
+    )
+    clamp_messages = [rec.getMessage() for rec in loguru_caplog.records if "Clamped scale-down" in rec.getMessage()]
+    if expect_clamp_log:
+        assert len(clamp_messages) == 1, f"expected exactly one clamp log, got {clamp_messages!r}"
+        assert f"proposed_delete={proposed_deletions}" in clamp_messages[0]
+        assert f"allowed_delete={expected_deletions}" in clamp_messages[0]
+    else:
+        assert clamp_messages == [], f"unexpected clamp log emitted: {clamp_messages!r}"
 
 
 def test_no_future_does_nothing() -> None:

--- a/cosmos_xenna/pipelines/v1/test_autoscaling.py
+++ b/cosmos_xenna/pipelines/v1/test_autoscaling.py
@@ -20,9 +20,13 @@ Simple ray example which uses ray to download, slightly modify and upload a dire
 See the "Running a multinode Ray job" of pipelines/examples/README.md for more info.
 """
 
+import os
 import time
+import uuid
+from typing import Optional
 
 import pytest
+import ray
 
 import cosmos_xenna.pipelines.v1 as pipelines_v1
 from cosmos_xenna.pipelines.private import resources
@@ -71,12 +75,325 @@ def test_autoscaling() -> None:
             mode_specific=pipelines_v1.StreamingSpecificSpec(
                 autoscale_interval_s=1,
                 autoscaler_verbosity_level=pipelines_v1.VerbosityLevel.DEBUG,
+                enable_backlog_aware_scaledown=False,
             ),
         ),
     )
     # Start the pipeline. If we run this locally, it will start a local ray cluster and submit our job. If we run it
     # with "uv run yotta launch --mode=ngc-ray", it will connect to the existing cluster and submit our job.
     pipelines_v1.run_pipeline(pipeline_spec)
+
+
+class _FixedCpuStage(pipelines_v1.Stage):
+    """Stage with explicit CPU/GPU shape for autoscaler regression tests.
+
+    When `tracker_name` is provided, the stage's `setup` hook
+    registers `(name, os.getpid())` with the named Ray actor at
+    that name - tests then query the tracker after the pipeline
+    completes to count distinct worker PIDs per stage.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        cpus: float,
+        gpus: float = 0.0,
+        setup_dur: float = 0.0,
+        process_dur: float = 0.0,
+        tracker_name: Optional[str] = None,
+    ) -> None:
+        self._name = name
+        self._cpus = cpus
+        self._gpus = gpus
+        self._setup_dur = float(setup_dur)
+        self._process_dur = float(process_dur)
+        self._tracker_name = tracker_name
+
+    @property
+    def stage_batch_size(self) -> int:
+        return 1
+
+    @property
+    def required_resources(self) -> pipelines_v1.Resources:
+        return pipelines_v1.Resources(cpus=self._cpus, gpus=self._gpus)
+
+    def setup(self, worker_metadata: resources.WorkerMetadata) -> None:
+        if self._tracker_name is not None:
+            tracker = ray.get_actor(self._tracker_name)
+            ray.get(tracker.register.remote(self._name, os.getpid()))
+        time.sleep(self._setup_dur)
+
+    def process_data(self, task: list[float]) -> list[float]:
+        time.sleep(self._process_dur)
+        return [x * 2 for x in task]
+
+
+# ---------------------------------------------------------------------------
+# Worker tracker -- a test-local Ray actor that records which stages
+# actually instantiated workers during a pipeline run. We use distinct PIDs
+# as the identity because each Ray worker actor runs in its own process; a
+# starved stage would only ever materialize the Phase 2 floor worker, so a
+# count > 1 for a given stage proves Phase 3 preemption (or Phase 4 headroom)
+# grew that stage beyond the floor.
+#
+# ``num_cpus=0`` is critical: the tracker must NOT consume any CPU from the
+# autoscaler's budget, otherwise tests that claim a 100-CPU cluster would
+# actually see 99 CPUs available to stage workers.
+# ---------------------------------------------------------------------------
+@ray.remote(num_cpus=0)
+class _WorkerTracker:
+    """Tracks unique (stage_name, pid) pairs registered by stage setups."""
+
+    def __init__(self) -> None:
+        self._pids: dict[str, set[int]] = {}
+
+    def register(self, stage_name: str, pid: int) -> None:
+        self._pids.setdefault(stage_name, set()).add(pid)
+
+    def counts(self) -> dict[str, int]:
+        return {k: len(v) for k, v in self._pids.items()}
+
+
+def _init_ray_for_autoscale_test(num_cpus: int, num_gpus: int) -> None:
+    """Pre-initialize Ray with the same options the pipeline uses.
+
+    ``run_pipeline`` eventually calls
+    ``cluster.init_or_connect_to_cluster`` which sets
+    ``RAY_MAX_LIMIT_FROM_API_SERVER`` / ``RAY_MAX_LIMIT_FROM_DATA_SOURCE``
+    to 40000 and then calls
+    ``ray.init(include_dashboard=True, ignore_reinit_error=True, ...)``.
+    When we need to override ``num_cpus``/``num_gpus`` for a contention
+    scenario we must call ``ray.init`` first with those counts, but we
+    must also set the same env vars **before** ``ray.init`` -- the
+    dashboard agent reads them at startup. If set after, the agent is
+    already running with smaller defaults and the pipeline's later
+    state-API queries (``limit=40000``) are rejected with HTTP 500 /
+    ``RayStateApiException``. The ``include_dashboard=True`` flag here
+    mirrors the pipeline's init so the dashboard agent is started
+    (otherwise the later pipeline init is a no-op under
+    ``ignore_reinit_error=True``).
+    """
+    # Direct assignment (not setdefault): a smaller inherited value for
+    # RAY_MAX_LIMIT_FROM_API_SERVER silently reproduces the exact HTTP
+    # 500 / RayStateApiException this helper exists to prevent, so the
+    # test must authoritatively set it.
+    os.environ["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = "1"
+    os.environ["RAY_MAX_LIMIT_FROM_API_SERVER"] = "40000"
+    os.environ["RAY_MAX_LIMIT_FROM_DATA_SOURCE"] = "40000"
+    ray.init(
+        num_cpus=num_cpus,
+        num_gpus=num_gpus,
+        include_dashboard=True,
+        ignore_reinit_error=True,
+    )
+
+
+@pytest.mark.slow
+def test_autoscaler_does_not_starve_downstream_under_cpu_pressure() -> None:
+    """Pin Phase 2 floor: downstream keeps >= 1 worker under upstream load.
+
+    Scenario:
+
+    - 100-CPU cluster, ``num_gpus=0``.
+    - Two stages, ``cpus=5`` each (max 20 workers would fit across both).
+    - Upstream is the per-task bottleneck (``process_dur=0.5``) with many
+      inputs, so the Rust autoscaler's throughput estimate drives it to
+      grow upstream aggressively.
+    - Downstream is fast per-task (``process_dur=0.05``) but cannot run
+      without a worker. If Phase 2's floor does not fire, the pipeline
+      deadlocks.
+
+    Two assertions, in order of diagnostic value:
+
+    1. ``counts['downstream'] >= 1`` via a ``_WorkerTracker``
+       named actor - direct state evidence that downstream actually
+       instantiated a worker. This is the canonical Phase 2 oracle.
+    2. A generous wall-clock backstop (``elapsed < 90s``) so that an
+       actual deadlock terminates the test instead of hanging.
+    """
+    _init_ray_for_autoscale_test(num_cpus=100, num_gpus=0)
+    try:
+        tracker = _WorkerTracker.options(name="floor_tracker").remote()  # type: ignore[attr-defined]
+        try:
+            spec = pipelines_v1.PipelineSpec(
+                input_data=list(range(50)),
+                stages=[
+                    _FixedCpuStage("upstream", cpus=5, process_dur=0.5, tracker_name="floor_tracker"),
+                    _FixedCpuStage("downstream", cpus=5, process_dur=0.05, tracker_name="floor_tracker"),
+                ],
+                config=pipelines_v1.PipelineConfig(
+                    logging_interval_s=2,
+                    mode_specific=pipelines_v1.StreamingSpecificSpec(
+                        autoscale_interval_s=1,
+                        autoscaler_verbosity_level=pipelines_v1.VerbosityLevel.DEBUG,
+                    ),
+                ),
+            )
+            start = time.monotonic()
+            pipelines_v1.run_pipeline(spec)
+            elapsed = time.monotonic() - start
+            counts = ray.get(tracker.counts.remote())
+            assert counts.get("downstream", 0) >= 1, (
+                f"Phase 2 floor failed: downstream never instantiated a worker; counts={counts}"
+            )
+            assert elapsed < 90.0, f"Pipeline took {elapsed:.1f}s; likely deadlocked; counts={counts}"
+        finally:
+            ray.kill(tracker)
+    finally:
+        ray.shutdown()
+
+
+@pytest.mark.slow
+def test_autoscaler_preempts_upstream_for_slow_downstream() -> None:
+    """Pin Phase 3 preemption: donors give up workers for a slower downstream.
+
+    Preemption contract: when the downstream stage is the cluster
+    bottleneck, the Rust max-min loop identifies it as the slowest
+    stage and pulls workers from upstream, which qualifies as a
+    donor because ``current_workers > 1`` and
+    ``throughput_if_one_removed > min_throughput``.
+
+    Scenario:
+
+    - 100-CPU cluster, ``num_gpus=0``.
+    - Two stages, ``cpus=5`` each.
+    - Upstream is fast per-task (``process_dur=0.05``) - intrinsically
+      needs few workers.
+    - Downstream is slow per-task (``process_dur=0.5``) - the cluster
+      bottleneck. The Rust max-min loop must identify downstream as the
+      slowest stage and pull workers from upstream (valid donor because
+      ``current_workers > 1`` and ``throughput_if_one_removed >
+      min_throughput``).
+
+    After the run, we query the ``_WorkerTracker`` actor for the set of
+    distinct PIDs that registered themselves. ``downstream > 1`` proves
+    at least one preemption cycle fired (or Phase 4 headroom grew
+    downstream, which is the same contract from the user's POV -
+    downstream did not stay stuck at the Phase 2 floor).
+    """
+    _init_ray_for_autoscale_test(num_cpus=100, num_gpus=0)
+    try:
+        tracker = _WorkerTracker.options(name="autoscale_tracker").remote()  # type: ignore[attr-defined]
+        try:
+            spec = pipelines_v1.PipelineSpec(
+                input_data=list(range(80)),
+                stages=[
+                    _FixedCpuStage("upstream", cpus=5, process_dur=0.05, tracker_name="autoscale_tracker"),
+                    _FixedCpuStage("downstream", cpus=5, process_dur=0.5, tracker_name="autoscale_tracker"),
+                ],
+                config=pipelines_v1.PipelineConfig(
+                    logging_interval_s=2,
+                    mode_specific=pipelines_v1.StreamingSpecificSpec(
+                        autoscale_interval_s=1,
+                        autoscaler_verbosity_level=pipelines_v1.VerbosityLevel.DEBUG,
+                        # Disable the backlog-aware scale-down guard for this
+                        # test: it intentionally clamps upstream deletions when
+                        # the upstream input queue is large, which is exactly
+                        # the situation we want Phase 3 preemption to resolve.
+                        # Leaving it ON would hide the preemption behavior we
+                        # are pinning here and surface as an AllocationError
+                        # (upstream keeps CPUs, downstream cannot be placed).
+                        enable_backlog_aware_scaledown=False,
+                    ),
+                ),
+            )
+            pipelines_v1.run_pipeline(spec)
+            counts = ray.get(tracker.counts.remote())
+            assert counts.get("downstream", 0) > 1, (
+                f"Phase 3 preemption failed: downstream stuck at "
+                f"{counts.get('downstream', 0)} unique worker(s); counts={counts}"
+            )
+        finally:
+            ray.kill(tracker)
+    finally:
+        ray.shutdown()
+
+
+def _install_fake_gpus(monkeypatch: pytest.MonkeyPatch, count: int) -> None:
+    """Patch NVML-based GPU discovery so tests can allocate synthetic GPUs.
+
+    ``cosmos_xenna.pipelines.private.resources.get_local_gpu_info`` is
+    the sole producer of node GPU inventory consumed by
+    ``make_cluster_resources_for_ray_cluster`` (via the
+    ``@ray.remote`` helper ``_get_node_info_from_current_node``).
+    Patching it yields deterministic fake GPUs without requiring
+    NVIDIA hardware / NVML and lets a CPU-only dev host exercise the
+    ``cpu=1, gpu=1`` tail stage that reproduces the production
+    ``AllocationError`` cascade.
+
+    Cross-process caveat: on a *single-node* local Ray cluster, the
+    remote ``_get_node_info_from_current_node`` task is scheduled on
+    the same node that started Ray (the driver host). Empirically,
+    Ray picks up the patched module attribute when the worker
+    imports ``resources``, so the cluster snapshot comes back with
+    the synthetic ``GpuInfo`` entries (visible in the
+    ``ClusterResources`` log line). On a multi-node cluster this
+    trick would not propagate, but multi-node clusters by
+    construction have real GPUs, so the patch is unnecessary there.
+    """
+    fake_gpus = [resources.GpuInfo(index=i, name=f"FakeGPU-{i}", uuid_=uuid.uuid4()) for i in range(count)]
+    monkeypatch.setattr(resources, "get_local_gpu_info", lambda: list(fake_gpus))
+
+
+@pytest.mark.slow
+def test_autoscaler_chain_with_gpu_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reproduce the AllocationError cascade.
+
+    Layout mirrors the failing production pipeline:
+
+    - Stage 0 ``producer``:  cpu=1, fast      (a lot of input for stage 1)
+    - Stage 1 ``transcode``: cpu=5, slow
+    - Stage 2 ``prep``:      cpu=3, medium
+    - Stage 3 ``gpu_tail``:  cpu=1, gpu=1
+
+    Two strict assertions:
+
+    1. Pipeline completes within a wall-clock upper bound. In the
+       production failure, the GPU stage never instantiated and Slurm
+       killed the job on inactivity timeout -- here pytest's per-test
+       timeout would fire instead.
+    2. ``counts['gpu_tail'] >= 1`` -- the GPU stage actually materialized
+       at least one worker. This is the precise negation of the
+       production cascade, which was "CPU companion could not be
+       placed, GPU stage never created, GPU idle".
+    """
+    _install_fake_gpus(monkeypatch, count=4)
+    _init_ray_for_autoscale_test(num_cpus=100, num_gpus=4)
+    try:
+        tracker = _WorkerTracker.options(name="chain_tracker").remote()  # type: ignore[attr-defined]
+        try:
+            spec = pipelines_v1.PipelineSpec(
+                input_data=list(range(60)),
+                stages=[
+                    _FixedCpuStage("producer", cpus=1, process_dur=0.05, tracker_name="chain_tracker"),
+                    _FixedCpuStage("transcode", cpus=5, process_dur=0.4, tracker_name="chain_tracker"),
+                    _FixedCpuStage("prep", cpus=3, process_dur=0.2, tracker_name="chain_tracker"),
+                    _FixedCpuStage(
+                        "gpu_tail",
+                        cpus=1,
+                        gpus=1,
+                        process_dur=0.3,
+                        tracker_name="chain_tracker",
+                    ),
+                ],
+                config=pipelines_v1.PipelineConfig(
+                    logging_interval_s=2,
+                    mode_specific=pipelines_v1.StreamingSpecificSpec(
+                        autoscale_interval_s=1,
+                        autoscaler_verbosity_level=pipelines_v1.VerbosityLevel.DEBUG,
+                    ),
+                ),
+            )
+            start = time.monotonic()
+            pipelines_v1.run_pipeline(spec)
+            elapsed = time.monotonic() - start
+            counts = ray.get(tracker.counts.remote())
+            assert elapsed < 180.0, f"Chain pipeline took {elapsed:.1f}s; possible deadlock; counts={counts}"
+            assert counts.get("gpu_tail", 0) >= 1, f"GPU tail starved (production cascade reproduced): counts={counts}"
+        finally:
+            ray.kill(tracker)
+    finally:
+        ray.shutdown()
 
 
 if __name__ == "__main__":

--- a/cosmos_xenna/pipelines/v1/test_autoscaling.py
+++ b/cosmos_xenna/pipelines/v1/test_autoscaling.py
@@ -23,7 +23,7 @@ See the "Running a multinode Ray job" of pipelines/examples/README.md for more i
 import os
 import time
 import uuid
-from typing import Optional
+from typing import Iterator, Optional
 
 import pytest
 import ray
@@ -31,6 +31,21 @@ import ray
 import cosmos_xenna.pipelines.v1 as pipelines_v1
 from cosmos_xenna.pipelines.private import resources
 from cosmos_xenna.utils.ci import is_running_in_cicd
+
+
+@pytest.fixture(autouse=True)
+def _ensure_clean_ray() -> Iterator[None]:
+    """Guarantee a fresh Ray cluster per test in this module.
+
+    Shutting down before AND after each test makes the order of
+    tests irrelevant and contains the blast radius of any future
+    test that forgets its own cleanup.
+    """
+    if ray.is_initialized():
+        ray.shutdown()
+    yield
+    if ray.is_initialized():
+        ray.shutdown()
 
 
 class _ProcessStage(pipelines_v1.Stage):
@@ -78,9 +93,10 @@ def test_autoscaling() -> None:
             ),
         ),
     )
-    # Start the pipeline. If we run this locally, it will start a local ray cluster and submit our job. If we run it
-    # with "uv run yotta launch --mode=ngc-ray", it will connect to the existing cluster and submit our job.
-    pipelines_v1.run_pipeline(pipeline_spec)
+    try:
+        pipelines_v1.run_pipeline(pipeline_spec)
+    finally:
+        ray.shutdown()
 
 
 class _FixedCpuStage(pipelines_v1.Stage):

--- a/cosmos_xenna/pipelines/v1/test_autoscaling.py
+++ b/cosmos_xenna/pipelines/v1/test_autoscaling.py
@@ -23,7 +23,6 @@ See the "Running a multinode Ray job" of pipelines/examples/README.md for more i
 import os
 import time
 import uuid
-from typing import Optional
 
 import pytest
 import ray
@@ -100,7 +99,7 @@ class _FixedCpuStage(pipelines_v1.Stage):
         gpus: float = 0.0,
         setup_dur: float = 0.0,
         process_dur: float = 0.0,
-        tracker_name: Optional[str] = None,
+        tracker_name: str | None = None,
     ) -> None:
         self._name = name
         self._cpus = cpus
@@ -128,21 +127,19 @@ class _FixedCpuStage(pipelines_v1.Stage):
         return [x * 2 for x in task]
 
 
-# ---------------------------------------------------------------------------
-# Worker tracker -- a test-local Ray actor that records which stages
-# actually instantiated workers during a pipeline run. We use distinct PIDs
-# as the identity because each Ray worker actor runs in its own process; a
-# starved stage would only ever materialize the Phase 2 floor worker, so a
-# count > 1 for a given stage proves Phase 3 preemption (or Phase 4 headroom)
-# grew that stage beyond the floor.
-#
-# ``num_cpus=0`` is critical: the tracker must NOT consume any CPU from the
-# autoscaler's budget, otherwise tests that claim a 100-CPU cluster would
-# actually see 99 CPUs available to stage workers.
-# ---------------------------------------------------------------------------
 @ray.remote(num_cpus=0)
 class _WorkerTracker:
-    """Tracks unique (stage_name, pid) pairs registered by stage setups."""
+    """Track unique ``(stage_name, pid)`` pairs registered by stage setups.
+
+    Each Ray worker actor runs in its own process, so distinct PIDs identify
+    distinct workers. A starved stage materialises only the Phase 2 floor
+    worker; a count > 1 for a given stage therefore proves Phase 3
+    preemption (or Phase 4 headroom) grew that stage beyond the floor.
+
+    ``num_cpus=0`` keeps the tracker out of the autoscaler's budget so a
+    test that claims a 100-CPU cluster sees all 100 CPUs available to
+    stage workers.
+    """
 
     def __init__(self) -> None:
         self._pids: dict[str, set[int]] = {}
@@ -154,7 +151,7 @@ class _WorkerTracker:
         return {k: len(v) for k, v in self._pids.items()}
 
 
-def _init_ray_for_autoscale_test(num_cpus: int, num_gpus: int) -> None:
+def _init_ray_for_autoscale_test(monkeypatch: pytest.MonkeyPatch, num_cpus: int, num_gpus: int) -> None:
     """Pre-initialize Ray with the same options the pipeline uses.
 
     ``run_pipeline`` eventually calls
@@ -162,7 +159,7 @@ def _init_ray_for_autoscale_test(num_cpus: int, num_gpus: int) -> None:
     ``RAY_MAX_LIMIT_FROM_API_SERVER`` / ``RAY_MAX_LIMIT_FROM_DATA_SOURCE``
     to 40000 and then calls
     ``ray.init(include_dashboard=True, ignore_reinit_error=True, ...)``.
-    When we need to override ``num_cpus``/``num_gpus`` for a contention
+    When we need to override ``num_cpus`` / ``num_gpus`` for a contention
     scenario we must call ``ray.init`` first with those counts, but we
     must also set the same env vars **before** ``ray.init`` -- the
     dashboard agent reads them at startup. If set after, the agent is
@@ -172,14 +169,17 @@ def _init_ray_for_autoscale_test(num_cpus: int, num_gpus: int) -> None:
     mirrors the pipeline's init so the dashboard agent is started
     (otherwise the later pipeline init is a no-op under
     ``ignore_reinit_error=True``).
+
+    ``monkeypatch.setenv`` is used so the env vars are reverted at the
+    end of the test instead of leaking into sibling tests run in the
+    same pytest process.
     """
-    # Direct assignment (not setdefault): a smaller inherited value for
-    # RAY_MAX_LIMIT_FROM_API_SERVER silently reproduces the exact HTTP
-    # 500 / RayStateApiException this helper exists to prevent, so the
-    # test must authoritatively set it.
-    os.environ["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = "1"
-    os.environ["RAY_MAX_LIMIT_FROM_API_SERVER"] = "40000"
-    os.environ["RAY_MAX_LIMIT_FROM_DATA_SOURCE"] = "40000"
+    # Authoritative assignment via monkeypatch: a smaller inherited value
+    # for RAY_MAX_LIMIT_FROM_API_SERVER silently reproduces the exact HTTP
+    # 500 / RayStateApiException this helper exists to prevent.
+    monkeypatch.setenv("RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES", "1")
+    monkeypatch.setenv("RAY_MAX_LIMIT_FROM_API_SERVER", "40000")
+    monkeypatch.setenv("RAY_MAX_LIMIT_FROM_DATA_SOURCE", "40000")
     ray.init(
         num_cpus=num_cpus,
         num_gpus=num_gpus,
@@ -189,7 +189,7 @@ def _init_ray_for_autoscale_test(num_cpus: int, num_gpus: int) -> None:
 
 
 @pytest.mark.slow
-def test_autoscaler_does_not_starve_downstream_under_cpu_pressure() -> None:
+def test_autoscaler_does_not_starve_downstream_under_cpu_pressure(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pin Phase 2 floor: downstream keeps >= 1 worker under upstream load.
 
     Scenario:
@@ -211,7 +211,7 @@ def test_autoscaler_does_not_starve_downstream_under_cpu_pressure() -> None:
     2. A generous wall-clock backstop (``elapsed < 90s``) so that an
        actual deadlock terminates the test instead of hanging.
     """
-    _init_ray_for_autoscale_test(num_cpus=100, num_gpus=0)
+    _init_ray_for_autoscale_test(monkeypatch, num_cpus=100, num_gpus=0)
     try:
         tracker = _WorkerTracker.options(name="floor_tracker").remote()  # type: ignore[attr-defined]
         try:
@@ -244,7 +244,7 @@ def test_autoscaler_does_not_starve_downstream_under_cpu_pressure() -> None:
 
 
 @pytest.mark.slow
-def test_autoscaler_preempts_upstream_for_slow_downstream() -> None:
+def test_autoscaler_preempts_upstream_for_slow_downstream(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pin Phase 3 preemption: donors give up workers for a slower downstream.
 
     Preemption contract: when the downstream stage is the cluster
@@ -271,7 +271,7 @@ def test_autoscaler_preempts_upstream_for_slow_downstream() -> None:
     downstream, which is the same contract from the user's POV -
     downstream did not stay stuck at the Phase 2 floor).
     """
-    _init_ray_for_autoscale_test(num_cpus=100, num_gpus=0)
+    _init_ray_for_autoscale_test(monkeypatch, num_cpus=100, num_gpus=0)
     try:
         tracker = _WorkerTracker.options(name="autoscale_tracker").remote()  # type: ignore[attr-defined]
         try:
@@ -321,18 +321,27 @@ def _install_fake_gpus(monkeypatch: pytest.MonkeyPatch, count: int) -> None:
     ``cpu=1, gpu=1`` tail stage that reproduces the production
     ``AllocationError`` cascade.
 
-    Cross-process caveat: on a *single-node* local Ray cluster, the
+    Cross-process caveat: on a *single-node* local Ray cluster the
     remote ``_get_node_info_from_current_node`` task is scheduled on
-    the same node that started Ray (the driver host). Empirically,
-    Ray picks up the patched module attribute when the worker
-    imports ``resources``, so the cluster snapshot comes back with
-    the synthetic ``GpuInfo`` entries (visible in the
-    ``ClusterResources`` log line). On a multi-node cluster this
-    trick would not propagate, but multi-node clusters by
-    construction have real GPUs, so the patch is unnecessary there.
+    the same node that started Ray (the driver host) and Ray re-imports
+    ``resources`` in the worker process, picking up the patched module
+    attribute. We verify the patch actually took effect by calling
+    ``get_local_gpu_info()`` back through the patched module reference.
+    On a multi-node cluster this trick would not propagate, but
+    multi-node clusters by construction have real GPUs, so the patch is
+    unnecessary there.
     """
     fake_gpus = [resources.GpuInfo(index=i, name=f"FakeGPU-{i}", uuid_=uuid.uuid4()) for i in range(count)]
     monkeypatch.setattr(resources, "get_local_gpu_info", lambda: list(fake_gpus))
+    # Sanity-check the patch reaches the symbol consumed by Ray's worker
+    # import path. A regression here (e.g. the producer moves modules)
+    # would otherwise surface as a hard-to-diagnose "GPU stage starved"
+    # failure inside the test body.
+    observed = resources.get_local_gpu_info()
+    assert len(observed) == count, (
+        f"_install_fake_gpus: expected {count} fake GPUs, got {len(observed)}; "
+        "patch likely missed the symbol consumed by ``_get_node_info_from_current_node``."
+    )
 
 
 @pytest.mark.slow
@@ -358,7 +367,7 @@ def test_autoscaler_chain_with_gpu_tail(monkeypatch: pytest.MonkeyPatch) -> None
        placed, GPU stage never created, GPU idle".
     """
     _install_fake_gpus(monkeypatch, count=4)
-    _init_ray_for_autoscale_test(num_cpus=100, num_gpus=4)
+    _init_ray_for_autoscale_test(monkeypatch, num_cpus=100, num_gpus=4)
     try:
         tracker = _WorkerTracker.options(name="chain_tracker").remote()  # type: ignore[attr-defined]
         try:

--- a/cosmos_xenna/pipelines/v1/test_autoscaling.py
+++ b/cosmos_xenna/pipelines/v1/test_autoscaling.py
@@ -23,6 +23,7 @@ See the "Running a multinode Ray job" of pipelines/examples/README.md for more i
 import os
 import time
 import uuid
+from typing import Optional
 
 import pytest
 import ray
@@ -99,7 +100,7 @@ class _FixedCpuStage(pipelines_v1.Stage):
         gpus: float = 0.0,
         setup_dur: float = 0.0,
         process_dur: float = 0.0,
-        tracker_name: str | None = None,
+        tracker_name: Optional[str] = None,
     ) -> None:
         self._name = name
         self._cpus = cpus
@@ -232,7 +233,7 @@ def test_autoscaler_does_not_starve_downstream_under_cpu_pressure(monkeypatch: p
             start = time.monotonic()
             pipelines_v1.run_pipeline(spec)
             elapsed = time.monotonic() - start
-            counts = ray.get(tracker.counts.remote())
+            counts: dict[str, int] = ray.get(tracker.counts.remote())  # type: ignore[attr-defined]
             assert counts.get("downstream", 0) >= 1, (
                 f"Phase 2 floor failed: downstream never instantiated a worker; counts={counts}"
             )
@@ -298,7 +299,7 @@ def test_autoscaler_preempts_upstream_for_slow_downstream(monkeypatch: pytest.Mo
                 ),
             )
             pipelines_v1.run_pipeline(spec)
-            counts = ray.get(tracker.counts.remote())
+            counts: dict[str, int] = ray.get(tracker.counts.remote())  # type: ignore[attr-defined]
             assert counts.get("downstream", 0) > 1, (
                 f"Phase 3 preemption failed: downstream stuck at "
                 f"{counts.get('downstream', 0)} unique worker(s); counts={counts}"
@@ -396,7 +397,7 @@ def test_autoscaler_chain_with_gpu_tail(monkeypatch: pytest.MonkeyPatch) -> None
             start = time.monotonic()
             pipelines_v1.run_pipeline(spec)
             elapsed = time.monotonic() - start
-            counts = ray.get(tracker.counts.remote())
+            counts: dict[str, int] = ray.get(tracker.counts.remote())  # type: ignore[attr-defined]
             assert elapsed < 180.0, f"Chain pipeline took {elapsed:.1f}s; possible deadlock; counts={counts}"
             assert counts.get("gpu_tail", 0) >= 1, f"GPU tail starved (production cascade reproduced): counts={counts}"
         finally:

--- a/cosmos_xenna/pipelines/v1/test_autoscaling.py
+++ b/cosmos_xenna/pipelines/v1/test_autoscaling.py
@@ -75,7 +75,6 @@ def test_autoscaling() -> None:
             mode_specific=pipelines_v1.StreamingSpecificSpec(
                 autoscale_interval_s=1,
                 autoscaler_verbosity_level=pipelines_v1.VerbosityLevel.DEBUG,
-                enable_backlog_aware_scaledown=False,
             ),
         ),
     )
@@ -287,14 +286,6 @@ def test_autoscaler_preempts_upstream_for_slow_downstream(monkeypatch: pytest.Mo
                     mode_specific=pipelines_v1.StreamingSpecificSpec(
                         autoscale_interval_s=1,
                         autoscaler_verbosity_level=pipelines_v1.VerbosityLevel.DEBUG,
-                        # Disable the backlog-aware scale-down guard for this
-                        # test: it intentionally clamps upstream deletions when
-                        # the upstream input queue is large, which is exactly
-                        # the situation we want Phase 3 preemption to resolve.
-                        # Leaving it ON would hide the preemption behavior we
-                        # are pinning here and surface as an AllocationError
-                        # (upstream keeps CPUs, downstream cannot be placed).
-                        enable_backlog_aware_scaledown=False,
                     ),
                 ),
             )

--- a/cosmos_xenna/ray_utils/actor_pool.py
+++ b/cosmos_xenna/ray_utils/actor_pool.py
@@ -677,6 +677,11 @@ class ActorPool(Generic[T, V]):
         return bool(self._task_queue) or self.num_used_slots > 0 or bool(self._completed_tasks)
 
     @property
+    def num_queued_tasks(self) -> int:
+        """Return the number of tasks queued in the pool waiting for an actor slot."""
+        return len(self._task_queue)
+
+    @property
     def num_ready_actors(self) -> int:
         return len(self._ready_actors)
 
@@ -727,7 +732,7 @@ class ActorPool(Generic[T, V]):
                 self._num_completed_tasks,
                 self._num_null_tasks,
                 self._num_dynamically_spawned_tasks,
-                len(self._task_queue),
+                self.num_queued_tasks,
                 len(self._completed_tasks) + ext_output_queue_size,
             ),
             monitoring.SlotStats(self.num_used_slots, self.num_empty_slots),

--- a/cosmos_xenna/ray_utils/test_actor_pool_num_queued_tasks.py
+++ b/cosmos_xenna/ray_utils/test_actor_pool_num_queued_tasks.py
@@ -16,12 +16,12 @@
 """Unit tests for the ``ActorPool.num_queued_tasks`` public property."""
 
 import collections
-from typing import Any
+from typing import Any, Optional
 
 from cosmos_xenna.ray_utils.actor_pool import ActorPool, Task
 
 
-def _make_task(node_id: str | None = None) -> Task[Any]:
+def _make_task(node_id: Optional[str] = None) -> Task[Any]:
     """Build a minimal ``Task`` instance with empty data for queue-length tests."""
     return Task(task_data=[], origin_node_id=node_id)
 

--- a/cosmos_xenna/ray_utils/test_actor_pool_num_queued_tasks.py
+++ b/cosmos_xenna/ray_utils/test_actor_pool_num_queued_tasks.py
@@ -16,12 +16,12 @@
 """Unit tests for the ``ActorPool.num_queued_tasks`` public property."""
 
 import collections
-from typing import Optional
+from typing import Any
 
 from cosmos_xenna.ray_utils.actor_pool import ActorPool, Task
 
 
-def _make_task(node_id: Optional[str] = None) -> Task:
+def _make_task(node_id: str | None = None) -> Task[Any]:
     """Build a minimal ``Task`` instance with empty data for queue-length tests."""
     return Task(task_data=[], origin_node_id=node_id)
 

--- a/cosmos_xenna/ray_utils/test_actor_pool_num_queued_tasks.py
+++ b/cosmos_xenna/ray_utils/test_actor_pool_num_queued_tasks.py
@@ -16,11 +16,12 @@
 """Unit tests for the ``ActorPool.num_queued_tasks`` public property."""
 
 import collections
+from typing import Optional
 
 from cosmos_xenna.ray_utils.actor_pool import ActorPool, Task
 
 
-def _make_task(node_id: str | None = None) -> Task:
+def _make_task(node_id: Optional[str] = None) -> Task:
     """Build a minimal ``Task`` instance with empty data for queue-length tests."""
     return Task(task_data=[], origin_node_id=node_id)
 

--- a/cosmos_xenna/ray_utils/test_actor_pool_num_queued_tasks.py
+++ b/cosmos_xenna/ray_utils/test_actor_pool_num_queued_tasks.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ``ActorPool.num_queued_tasks`` public property."""
+
+import collections
+
+from cosmos_xenna.ray_utils.actor_pool import ActorPool, Task
+
+
+def _make_task(node_id: str | None = None) -> Task:
+    """Build a minimal ``Task`` instance with empty data for queue-length tests."""
+    return Task(task_data=[], origin_node_id=node_id)
+
+
+def test_num_queued_tasks_zero_on_empty_pool() -> None:
+    """Fresh pool with an empty task queue reports zero queued tasks."""
+    pool = object.__new__(ActorPool)
+    pool._task_queue = collections.deque()
+
+    assert pool.num_queued_tasks == 0
+
+
+def test_num_queued_tasks_reflects_appended_tasks() -> None:
+    """Property mirrors the length of the internal task queue after appends."""
+    pool = object.__new__(ActorPool)
+    pool._task_queue = collections.deque()
+    pool._task_queue.append(_make_task())
+    pool._task_queue.append(_make_task())
+    pool._task_queue.append(_make_task())
+
+    assert pool.num_queued_tasks == 3


### PR DESCRIPTION
When an upstream source stage finishes, the rust `FragmentationBasedAutoscaler` proposes aggressive worker deletions (eg. 20 -> 2 in one cycle) because measured throughput drops to zero. With many tasks still queued, downstream GPU stages then starve while CPU queues stay full.

Clamp rust's proposed deletions so every active stage retains at least `max(MIN_WORKERS_PER_STAGE, ceil(inflight/slots), ceil(backlog/(slots*batch)))` workers. Deletions are only reduced, never amplified.

Finished-stage teardown bypasses the guard via is_done.

This works in concert with https://github.com/nvidia-cosmos/cosmos-xenna/pull/36 (rate-limit guard). Each addresses a different failure mode (cliff vs starvation).


Default ``False`` - Rust-proposed worker deletions pass through unchanged.