### PR TITLE
fix: tolerate None gpustat fields on DGX Spark GB10

### DIFF
--- a/cosmos_xenna/ray_utils/resource_monitor.py
+++ b/cosmos_xenna/ray_utils/resource_monitor.py
@@ -39,7 +39,7 @@ import pathlib
 import resource
 import threading
 import time
-from typing import Optional
+from typing import Optional, TypeVar
 
 import attrs
 import jinja2
@@ -264,6 +264,26 @@ def get_filesystem_usage(path: pathlib.Path) -> tuple[int, int]:
     return used_bytes, total_bytes
 
 
+_T = TypeVar("_T")
+
+
+def _safe_gpu_attr(gpu: object, name: str, default: _T) -> _T:
+    """Read a ``gpustat`` GPU attribute, returning ``default`` when unavailable.
+
+    ``gpustat`` eagerly coerces some NVML fields with ``int(...)`` inside
+    ``@property`` getters, which raises ``TypeError`` when NVML returns ``None``
+    (e.g. ``memory.used`` / ``memory.total`` / ``power.limit`` on DGX Spark's
+    GB10 integrated GPU, which shares unified memory with the CPU). Other
+    getters return ``None`` directly. Collapse both cases to ``default`` so a
+    single missing field does not break the whole metrics loop.
+    """
+    try:
+        value = getattr(gpu, name)
+    except (TypeError, KeyError, AttributeError):
+        return default
+    return default if value is None else value
+
+
 class ResourceMonitor:
     """Class to fetch real-time metrics of system resources."""
 
@@ -306,11 +326,11 @@ class ResourceMonitor:
             else:
                 gpus = [
                     GPUData(
-                        utilization=gpu.utilization,
-                        memory_used=gpu.memory_used,
-                        memory_total=gpu.memory_total,
-                        power_usage_percentage=gpu.power_draw,
-                        power_limit_w=gpu.power_limit,
+                        utilization=_safe_gpu_attr(gpu, "utilization", 0.0),
+                        memory_used=_safe_gpu_attr(gpu, "memory_used", 0),
+                        memory_total=_safe_gpu_attr(gpu, "memory_total", 0),
+                        power_usage_percentage=_safe_gpu_attr(gpu, "power_draw", None),
+                        power_limit_w=_safe_gpu_attr(gpu, "power_limit", None),
                     )
                     for gpu in gpu_stats
                 ]

--- a/cosmos_xenna/ray_utils/resource_monitor.py
+++ b/cosmos_xenna/ray_utils/resource_monitor.py
@@ -39,7 +39,7 @@ import pathlib
 import resource
 import threading
 import time
-from typing import Any, Optional, TypeVar, overload
+from typing import Any, Optional
 
 import attrs
 import jinja2
@@ -264,18 +264,7 @@ def get_filesystem_usage(path: pathlib.Path) -> tuple[int, int]:
     return used_bytes, total_bytes
 
 
-_T = TypeVar("_T")
-
-
-@overload
-def _safe_gpu_attr(gpu: object, name: str, default: None) -> Any: ...
-
-
-@overload
-def _safe_gpu_attr(gpu: object, name: str, default: _T) -> _T: ...
-
-
-def _safe_gpu_attr(gpu: object, name: str, default: object) -> object:
+def _safe_gpu_attr(gpu: object, name: str, default: Any) -> Any:
     """Read a ``gpustat`` GPU attribute, returning ``default`` when unavailable.
 
     ``gpustat`` eagerly coerces some NVML fields with ``int(...)`` inside
@@ -284,11 +273,6 @@ def _safe_gpu_attr(gpu: object, name: str, default: object) -> object:
     GB10 integrated GPU, which shares unified memory with the CPU). Other
     getters return ``None`` directly. Collapse both cases to ``default`` so a
     single missing field does not break the whole metrics loop.
-
-    The ``default=None`` overload returns ``Any`` because the real value (when
-    present) is whatever ``gpustat`` exposes for that field — typically ``int``
-    or ``float`` — and forcing callers to cast through ``object`` would just
-    add noise.
     """
     try:
         value = getattr(gpu, name)

--- a/cosmos_xenna/ray_utils/resource_monitor.py
+++ b/cosmos_xenna/ray_utils/resource_monitor.py
@@ -39,7 +39,7 @@ import pathlib
 import resource
 import threading
 import time
-from typing import Optional, TypeVar
+from typing import Any, Optional, TypeVar, overload
 
 import attrs
 import jinja2
@@ -267,7 +267,15 @@ def get_filesystem_usage(path: pathlib.Path) -> tuple[int, int]:
 _T = TypeVar("_T")
 
 
-def _safe_gpu_attr(gpu: object, name: str, default: _T) -> _T:
+@overload
+def _safe_gpu_attr(gpu: object, name: str, default: None) -> Any: ...
+
+
+@overload
+def _safe_gpu_attr(gpu: object, name: str, default: _T) -> _T: ...
+
+
+def _safe_gpu_attr(gpu: object, name: str, default: object) -> object:
     """Read a ``gpustat`` GPU attribute, returning ``default`` when unavailable.
 
     ``gpustat`` eagerly coerces some NVML fields with ``int(...)`` inside
@@ -276,6 +284,11 @@ def _safe_gpu_attr(gpu: object, name: str, default: _T) -> _T:
     GB10 integrated GPU, which shares unified memory with the CPU). Other
     getters return ``None`` directly. Collapse both cases to ``default`` so a
     single missing field does not break the whole metrics loop.
+
+    The ``default=None`` overload returns ``Any`` because the real value (when
+    present) is whatever ``gpustat`` exposes for that field — typically ``int``
+    or ``float`` — and forcing callers to cast through ``object`` would just
+    add noise.
     """
     try:
         value = getattr(gpu, name)

--- a/cosmos_xenna/ray_utils/resource_monitor_test.py
+++ b/cosmos_xenna/ray_utils/resource_monitor_test.py
@@ -37,7 +37,7 @@ class _FakeGpu:
     either raises ``TypeError`` (eager ``int()`` coercion) or returns ``None``.
     """
 
-    def __init__(self, entry: dict[str, object]) -> None:
+    def __init__(self, entry: dict[str, int | None]) -> None:
         self._entry = entry
 
     @property
@@ -45,13 +45,16 @@ class _FakeGpu:
         v = self._entry.get("utilization.gpu")
         return int(v) if v is not None else None
 
+    # The int(...) calls below are deliberately unsafe — they reproduce gpustat's
+    # eager coercion that raises TypeError on None. The type: ignore comments
+    # acknowledge the unsafety pyright would otherwise flag.
     @property
     def memory_used(self) -> int:
-        return int(self._entry["memory.used"])  # raises TypeError when None
+        return int(self._entry["memory.used"])  # type: ignore[arg-type]
 
     @property
     def memory_total(self) -> int:
-        return int(self._entry["memory.total"])  # raises TypeError when None
+        return int(self._entry["memory.total"])  # type: ignore[arg-type]
 
     @property
     def power_draw(self) -> int | None:
@@ -60,7 +63,7 @@ class _FakeGpu:
 
     @property
     def power_limit(self) -> int:
-        return int(self._entry["power.limit"])  # raises TypeError when None
+        return int(self._entry["power.limit"])  # type: ignore[arg-type]
 
 
 def test_returns_value_when_present() -> None:

--- a/cosmos_xenna/ray_utils/resource_monitor_test.py
+++ b/cosmos_xenna/ray_utils/resource_monitor_test.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for resource_monitor helpers.
+
+Focus: ``_safe_gpu_attr`` must tolerate the two shapes of "missing field" that
+``gpustat`` exposes on hardware where NVML returns ``None`` for some queries
+(e.g. DGX Spark GB10, which shares unified memory with the CPU and reports
+``memory.used`` / ``memory.total`` / ``power.limit`` as ``None``):
+
+1. Property getters that eagerly call ``int(self.entry[key])`` raise
+   ``TypeError`` when the entry is ``None``.
+2. Other getters return ``None`` directly.
+"""
+
+from __future__ import annotations
+
+from cosmos_xenna.ray_utils.resource_monitor import _safe_gpu_attr
+
+
+class _FakeGpu:
+    """Stand-in for a ``gpustat`` GPU object with configurable per-field behavior.
+
+    Mirrors the real library: accessing a field whose NVML value is ``None``
+    either raises ``TypeError`` (eager ``int()`` coercion) or returns ``None``.
+    """
+
+    def __init__(self, entry: dict[str, object]) -> None:
+        self._entry = entry
+
+    @property
+    def utilization(self) -> int | None:
+        v = self._entry.get("utilization.gpu")
+        return int(v) if v is not None else None
+
+    @property
+    def memory_used(self) -> int:
+        return int(self._entry["memory.used"])  # raises TypeError when None
+
+    @property
+    def memory_total(self) -> int:
+        return int(self._entry["memory.total"])  # raises TypeError when None
+
+    @property
+    def power_draw(self) -> int | None:
+        v = self._entry.get("power.draw")
+        return int(v) if v is not None else None
+
+    @property
+    def power_limit(self) -> int:
+        return int(self._entry["power.limit"])  # raises TypeError when None
+
+
+def test_returns_value_when_present() -> None:
+    gpu = _FakeGpu({"memory.used": 2048, "memory.total": 16384, "utilization.gpu": 42})
+    assert _safe_gpu_attr(gpu, "memory_used", 0) == 2048
+    assert _safe_gpu_attr(gpu, "memory_total", 0) == 16384
+    assert _safe_gpu_attr(gpu, "utilization", 0.0) == 42
+
+
+def test_returns_default_when_property_raises_type_error() -> None:
+    # Reproduces the DGX Spark GB10 failure mode.
+    gpu = _FakeGpu({"memory.used": None, "memory.total": None, "power.limit": None})
+    assert _safe_gpu_attr(gpu, "memory_used", 0) == 0
+    assert _safe_gpu_attr(gpu, "memory_total", 0) == 0
+    assert _safe_gpu_attr(gpu, "power_limit", None) is None
+
+
+def test_returns_default_when_property_returns_none() -> None:
+    gpu = _FakeGpu({"utilization.gpu": None, "power.draw": None})
+    assert _safe_gpu_attr(gpu, "utilization", 0.0) == 0.0
+    assert _safe_gpu_attr(gpu, "power_draw", None) is None
+
+
+def test_returns_default_when_attribute_missing() -> None:
+    assert _safe_gpu_attr(object(), "does_not_exist", 7) == 7
+
+
+def test_preserves_falsy_non_none_values() -> None:
+    # Genuine zero readings must not be replaced by the default.
+    gpu = _FakeGpu({"memory.used": 0, "utilization.gpu": 0})
+    assert _safe_gpu_attr(gpu, "memory_used", 999) == 0
+    assert _safe_gpu_attr(gpu, "utilization", 999.0) == 0

--- a/cosmos_xenna/ray_utils/resource_monitor_test.py
+++ b/cosmos_xenna/ray_utils/resource_monitor_test.py
@@ -64,10 +64,23 @@ class _FakeGpu:
 
 
 def test_returns_value_when_present() -> None:
-    gpu = _FakeGpu({"memory.used": 2048, "memory.total": 16384, "utilization.gpu": 42})
+    gpu = _FakeGpu(
+        {
+            "memory.used": 2048,
+            "memory.total": 16384,
+            "utilization.gpu": 42,
+            "power.draw": 150,
+            "power.limit": 250,
+        }
+    )
     assert _safe_gpu_attr(gpu, "memory_used", 0) == 2048
     assert _safe_gpu_attr(gpu, "memory_total", 0) == 16384
     assert _safe_gpu_attr(gpu, "utilization", 0.0) == 42
+    # default=None must not collapse a real reading to None — covers both
+    # gpustat shapes: power_draw returns the value directly, power_limit
+    # comes back through an int(...) coercion.
+    assert _safe_gpu_attr(gpu, "power_draw", None) == 150
+    assert _safe_gpu_attr(gpu, "power_limit", None) == 250
 
 
 def test_returns_default_when_property_raises_type_error() -> None:

--- a/src/pipelines/private/scheduling/allocator.rs
+++ b/src/pipelines/private/scheduling/allocator.rs
@@ -157,7 +157,7 @@ impl WorkerAllocator {
         };
 
         if let Some(initial_workers) = workers {
-            this.add_workers(initial_workers.into_iter())?;
+            this.add_workers(initial_workers)?;
         }
         Ok(this)
     }

--- a/src/pipelines/private/scheduling/autoscaling_algorithms.rs
+++ b/src/pipelines/private/scheduling/autoscaling_algorithms.rs
@@ -276,11 +276,7 @@ impl SpeedAndNumberOfReturnsEstimator {
             .iter_mut()
             .map(|e| e.maybe_get_average_num_returns(now))
             .collect();
-        for (i, (ms, mr)) in maybe_speeds
-            .into_iter()
-            .zip(maybe_returns)
-            .enumerate()
-        {
+        for (i, (ms, mr)) in maybe_speeds.into_iter().zip(maybe_returns).enumerate() {
             if ms.is_some() {
                 self.last_valid_speeds[i] = ms;
             }

--- a/src/pipelines/private/scheduling/autoscaling_algorithms.rs
+++ b/src/pipelines/private/scheduling/autoscaling_algorithms.rs
@@ -278,7 +278,7 @@ impl SpeedAndNumberOfReturnsEstimator {
             .collect();
         for (i, (ms, mr)) in maybe_speeds
             .into_iter()
-            .zip(maybe_returns.into_iter())
+            .zip(maybe_returns)
             .enumerate()
         {
             if ms.is_some() {
@@ -996,7 +996,7 @@ pub fn run_fragmentation_autoscaler(
         .collect();
     let input_samples_per_sample =
         calculate_input_samples_per_sample(&stage_batch_sizes, &num_returns_per_batch);
-    for (stage, val) in stages.iter_mut().zip(input_samples_per_sample.into_iter()) {
+    for (stage, val) in stages.iter_mut().zip(input_samples_per_sample) {
         stage.num_input_samples_per_sample = Some(val);
     }
 


### PR DESCRIPTION
The GB10 integrated GPU shares unified memory with the CPU, so NVML reports memory.used / memory.total / power.limit as None. gpustat's property getters eagerly coerce these with int(...), which raises TypeError and breaks NodeResourceMonitor's metrics loop entirely.

Route every gpustat field through _safe_gpu_attr, which maps both TypeError/KeyError/AttributeError and None returns to a default (0 for memory/utilization, None for the already-Optional power fields).