### PR TITLE
chore(tests): silence marker and TestS3Object warnings in unit tests

### DIFF
--- a/cosmos_xenna/file_distribution/test_file_distribution.py
+++ b/cosmos_xenna/file_distribution/test_file_distribution.py
@@ -54,6 +54,8 @@ class TestS3Object:
     key: str
     bytes: bytes
 
+    __test__ = False  # Not a pytest test class; the "Test" prefix is incidental.
+
 
 @pytest.fixture
 def testing_info():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ log_cli_level = "INFO"
 addopts = "-m 'not slow'"
 markers = [
     "slow: marks tests as slow to run",
+    "L1: level-1 test tier (used by external CI runners)",
+    "CPU: test runs on CPU-only hardware (used by external CI runners)",
 ]
 
 


### PR DESCRIPTION
Clean up some of the warnings in the unit test summary:

- Declare `L1` and `CPU` in `[tool.pytest.ini_options].markers` so the external-CI tier decorators on `reap_pids_test.py` stop emitting PytestUnknownMarkWarning (14 occurrences per run).
- Set `__test__ = False` on the `TestS3Object` attrs dataclass in `test_file_distribution.py` so pytest doesn't try to collect it as a test class.