### PR TITLE
fix: explicit CPU floor and actionable resource-shortage errors

### DIFF
--- a/cosmos_xenna/pipelines/private/resources.py
+++ b/cosmos_xenna/pipelines/private/resources.py
@@ -766,7 +766,9 @@ def make_cluster_resources_for_ray_cluster(
         node_gpus = _get_gpus(reported_resources[node_id], info)
         out_dict[str(node_id)] = NodeResources(
             used_cpus=0.0,
-            total_cpus=math.floor(_get_cpu_count(reported_resources[node_id], info) * cpu_allocation_percentage),
+            total_cpus=max(
+                0, math.floor(_get_cpu_count(reported_resources[node_id], info) * cpu_allocation_percentage)
+            ),
             gpus=[
                 GpuResources(
                     index=x.index,

--- a/cosmos_xenna/pipelines/private/resources.py
+++ b/cosmos_xenna/pipelines/private/resources.py
@@ -22,6 +22,7 @@ Shapes are meant to specified by users on a per-stage basis.
 
 from __future__ import annotations
 
+import math
 import os
 import uuid
 from typing import Any, Optional, Union
@@ -765,7 +766,7 @@ def make_cluster_resources_for_ray_cluster(
         node_gpus = _get_gpus(reported_resources[node_id], info)
         out_dict[str(node_id)] = NodeResources(
             used_cpus=0.0,
-            total_cpus=int(_get_cpu_count(reported_resources[node_id], info) * cpu_allocation_percentage),
+            total_cpus=math.floor(_get_cpu_count(reported_resources[node_id], info) * cpu_allocation_percentage),
             gpus=[
                 GpuResources(
                     index=x.index,

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -658,7 +658,7 @@ def _verify_enough_resources(pipeline_spec: specs.PipelineSpec, cluster_resource
     if approx.float_lt(cluster_resource_totals.gpus, required_resources.gpus):
         raise ValueError(
             f"Not enough GPU resources to run pipeline in {mode_name} mode. Pipeline requires "
-            f"{required_resources.gpus} GPUs but only {cluster_resource_totals.gpus} are available.\n{summary_string}"
+            f"{required_resources.gpus:.2f} GPUs but only {cluster_resource_totals.gpus:.2f} are available.\n{summary_string}"
         )
 
 

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -637,19 +637,22 @@ def _verify_enough_resources(pipeline_spec: specs.PipelineSpec, cluster_resource
         required_resources = required_resources.add(resources_per_worker.multiply_by(num_required))
 
     summary_string = (
-        f"If running locally, you can run the pipeline in batch mode by setting the config.execution_mode to BATCH.\n"
+        f"To fit, reduce per-worker CPU/GPU on individual stages (Stage.required_resources) or their worker counts "
+        f"(num_workers / num_workers_per_node). BATCH mode (config.execution_mode=BATCH) is another option: "
+        f"stages run sequentially, so resource demand is the max of any single stage instead of the sum across stages "
+        f"-- this won't help if a single stage alone requires more than what is available.\n"
         f"Cluster resources: {cluster_resource_totals}\n"
         f"Required resources: {required_resources}"
     )
     if approx.float_lt(cluster_resource_totals.cpus, required_resources.cpus):
         raise ValueError(
             f"Not enough CPU resources to run pipeline in streaming mode. Pipeline requires "
-            f"{required_resources.cpus} but only {cluster_resource_totals.cpus} are available.\n{summary_string}"
+            f"{required_resources.cpus} CPUs but only {cluster_resource_totals.cpus} are available.\n{summary_string}"
         )
     if approx.float_lt(cluster_resource_totals.gpus, required_resources.gpus):
         raise ValueError(
             f"Not enough GPU resources to run pipeline in streaming mode. Pipeline requires "
-            f"{required_resources.gpus} but only {cluster_resource_totals.gpus} are available.\n{summary_string}"
+            f"{required_resources.gpus} GPUs but only {cluster_resource_totals.gpus} are available.\n{summary_string}"
         )
 
 

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -653,12 +653,14 @@ def _verify_enough_resources(pipeline_spec: specs.PipelineSpec, cluster_resource
     if approx.float_lt(cluster_resource_totals.cpus, required_resources.cpus):
         raise ValueError(
             f"Not enough CPU resources to run pipeline in {mode_name} mode. Pipeline requires "
-            f"{required_resources.cpus:.2f} CPUs but only {cluster_resource_totals.cpus:.2f} are available.\n{summary_string}"
+            f"{required_resources.cpus:.2f} CPUs but only {cluster_resource_totals.cpus:.2f} are available.\n"
+            f"{summary_string}"
         )
     if approx.float_lt(cluster_resource_totals.gpus, required_resources.gpus):
         raise ValueError(
             f"Not enough GPU resources to run pipeline in {mode_name} mode. Pipeline requires "
-            f"{required_resources.gpus:.2f} GPUs but only {cluster_resource_totals.gpus:.2f} are available.\n{summary_string}"
+            f"{required_resources.gpus:.2f} GPUs but only {cluster_resource_totals.gpus:.2f} are available.\n"
+            f"{summary_string}"
         )
 
 

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -636,22 +636,28 @@ def _verify_enough_resources(pipeline_spec: specs.PipelineSpec, cluster_resource
         resources_per_worker = stage.stage.required_resources.to_pool()
         required_resources = required_resources.add(resources_per_worker.multiply_by(num_required))
 
+    mode_name = pipeline_spec.config.execution_mode.name
+    remediation = (
+        "To fit, reduce per-worker CPU/GPU on individual stages (Stage.required_resources) or their worker counts "
+        "(num_workers / num_workers_per_node)."
+    )
+    if pipeline_spec.config.execution_mode == specs.ExecutionMode.STREAMING:
+        remediation += (
+            " BATCH mode (config.execution_mode=BATCH) is another option: stages run sequentially, so resource "
+            "demand is the max of any single stage instead of the sum across stages -- this won't help if a "
+            "single stage alone requires more than what is available."
+        )
     summary_string = (
-        f"To fit, reduce per-worker CPU/GPU on individual stages (Stage.required_resources) or their worker counts "
-        f"(num_workers / num_workers_per_node). BATCH mode (config.execution_mode=BATCH) is another option: "
-        f"stages run sequentially, so resource demand is the max of any single stage instead of the sum across stages "
-        f"-- this won't help if a single stage alone requires more than what is available.\n"
-        f"Cluster resources: {cluster_resource_totals}\n"
-        f"Required resources: {required_resources}"
+        f"{remediation}\nCluster resources: {cluster_resource_totals}\nRequired resources: {required_resources}"
     )
     if approx.float_lt(cluster_resource_totals.cpus, required_resources.cpus):
         raise ValueError(
-            f"Not enough CPU resources to run pipeline in streaming mode. Pipeline requires "
+            f"Not enough CPU resources to run pipeline in {mode_name} mode. Pipeline requires "
             f"{required_resources.cpus} CPUs but only {cluster_resource_totals.cpus} are available.\n{summary_string}"
         )
     if approx.float_lt(cluster_resource_totals.gpus, required_resources.gpus):
         raise ValueError(
-            f"Not enough GPU resources to run pipeline in streaming mode. Pipeline requires "
+            f"Not enough GPU resources to run pipeline in {mode_name} mode. Pipeline requires "
             f"{required_resources.gpus} GPUs but only {cluster_resource_totals.gpus} are available.\n{summary_string}"
         )
 

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -653,7 +653,7 @@ def _verify_enough_resources(pipeline_spec: specs.PipelineSpec, cluster_resource
     if approx.float_lt(cluster_resource_totals.cpus, required_resources.cpus):
         raise ValueError(
             f"Not enough CPU resources to run pipeline in {mode_name} mode. Pipeline requires "
-            f"{required_resources.cpus} CPUs but only {cluster_resource_totals.cpus} are available.\n{summary_string}"
+            f"{required_resources.cpus:.2f} CPUs but only {cluster_resource_totals.cpus:.2f} are available.\n{summary_string}"
         )
     if approx.float_lt(cluster_resource_totals.gpus, required_resources.gpus):
         raise ValueError(

--- a/cosmos_xenna/ray_utils/test_adjust_actors_allocation_guard.py
+++ b/cosmos_xenna/ray_utils/test_adjust_actors_allocation_guard.py
@@ -355,7 +355,7 @@ class TestSpmdAllocationOrdering:
 
         pool._find_rendevous_params_for_worker_group = MagicMock(side_effect=_rendezvous_then_fail)
 
-        with pytest.raises(RuntimeError, match="simulated ray.get RPC failure"):
+        with pytest.raises(RuntimeError, match=r"simulated ray\.get RPC failure"):
             pool._add_worker_group(wg)
 
         pool._allocator.remove_worker.assert_called_once_with("wg-spmd-rollback")


### PR DESCRIPTION
## Summary

Two small fixes to the STREAMING resource-check path, driven by user reports of
confusing behavior and unhelpful errors on CPU-constrained hosts (e.g. 8-core
workstations).

### `resources.py`: use `math.floor` instead of `int()`

`int()` on a non-negative float truncates identically to `math.floor`, but the
intent at the CPU-headroom reservation site is ambiguous -- a reader has to
know the input is never negative to rule out truncating-toward-zero. Switch to
`math.floor` to make the rounding behavior explicit. No behavior change.

### `streaming.py`: actionable resource-shortage errors

The previous error pointed users at `config.execution_mode=BATCH` but never
explained when BATCH actually helps, and never mentioned the most common fix
(lowering per-stage resource demand). Rewrite the shared summary so it:

- Leads with per-stage / worker-count remediation (`Stage.required_resources`,
  `num_workers`, `num_workers_per_node`) -- the fix that works in both modes.
- Keeps the BATCH suggestion, but explains the actual mechanism (stages run
  sequentially, so demand is max instead of sum) and the caveat (BATCH won't
  help if a single stage alone already exceeds available resources).
- Appends `CPU` / `GPU` units to the "requires X but only Y are available"
  line so the numbers are readable.

## Validation

- `ruff format --check` clean on both files
- `ruff check` clean on both files
- `math.floor(N * p)` equals `int(N * p)` for all non-negative `N, p` that can
  appear here, so there is no change in allocated CPU count on any real host.

## Commits

- `5910798 fix: use math.floor for explicit CPU count truncation`
- `9de9f04 fix: make resource-shortage errors actionable`

Both commits DCO-signed.