### PR TITLE
fix: refactor autoscaler FGD to use pure scoring overlay

### DIFF
--- a/src/pipelines/private/scheduling/autoscaling_algorithms.rs
+++ b/src/pipelines/private/scheduling/autoscaling_algorithms.rs
@@ -2713,4 +2713,370 @@ mod tests {
             (estimated_gpu_usage / total_cluster_gpus as f32) * 100.0
         );
     }
+
+    // --------------------
+    // Reuse-bookkeeping regression tests
+    // --------------------
+    //
+    // These tests exercise `remove_best_worker_fn` → `add_worker_fn` back-to-back on the
+    // same stage within one planning pass. This is the production code path that consumes
+    // the new `AllocationResult::reused_worker_id` field, and the path whose correctness
+    // depends on the tightened borrowing / `HashMap::remove`-consume pattern in
+    // `autoscaling_algorithms.rs`. A regression in any of those areas (stale to-remove
+    // entries, accidental `Worker` clones, missed cluster re-allocation, desynced
+    // `stage.current_workers`, etc.) will surface here.
+
+    // FGD's `worker_reuse_fragmentation_equivalent` knob: large enough to make any
+    // in-pool reuse candidate strictly preferred over a fresh allocation. The exact
+    // magnitude doesn't matter when the reuse pool is empty — the fresh-allocation
+    // test re-uses this constant to document that the bonus is inert on that path.
+    const REUSE_BONUS_FORCING_REUSE: f32 = 10.0;
+
+    /// Builds a tiny `StageInternal` suitable for driving `add_worker_fn` /
+    /// `remove_best_worker_fn` directly in tests.
+    ///
+    /// The `speed_per_worker` / `stage_batch_size` / `num_returns_per_batch` /
+    /// `num_input_samples_per_sample` fields are unused on the add/remove bookkeeping
+    /// path (those are `throughput()`-only inputs), but `StageInternal` requires them.
+    fn make_stage_internal(
+        name: &str,
+        shape: rds::WorkerShape,
+        current_workers: usize,
+    ) -> StageInternal {
+        StageInternal {
+            name: name.to_string(),
+            current_workers,
+            speed_per_worker: Some(1.0),
+            stage_batch_size: 1,
+            num_returns_per_batch: Some(1.0),
+            num_input_samples_per_sample: Some(1.0),
+            shape,
+            requested_num_workers: None,
+            is_finished: false,
+        }
+    }
+
+    fn make_workload_for_stage(stage: &StageInternal) -> frag::Workload {
+        frag::Workload {
+            stages: vec![frag::Stage {
+                frequency: 1.0,
+                shape: stage.shape.clone(),
+            }],
+        }
+    }
+
+    /// Seeds an `AutoscaleContext` with a cluster and a single pre-existing worker for
+    /// `stage`. The worker is registered in `current_workers_per_stage` and its
+    /// allocation is applied to the cluster, mirroring what `run_fragmentation_autoscaler`
+    /// does after ingesting `ProblemState`.
+    fn seed_context<'a>(
+        cluster: rds::ClusterResources,
+        worker_id_factory: &'a mut WorkerIdFactory,
+        stage_name: &str,
+        seeded_worker: rds::Worker,
+    ) -> AutoscaleContext<'a> {
+        let mut cluster = cluster;
+        cluster
+            .allocate(&seeded_worker.allocation)
+            .expect("seed worker allocation");
+
+        let mut current_workers_per_stage: HashMap<String, HashMap<String, rds::Worker>> =
+            HashMap::new();
+        let mut workers = HashMap::new();
+        workers.insert(seeded_worker.id.clone(), seeded_worker);
+        current_workers_per_stage.insert(stage_name.to_string(), workers);
+
+        let mut workers_to_add_map: HashMap<String, Vec<rds::Worker>> = HashMap::new();
+        workers_to_add_map.insert(stage_name.to_string(), Vec::new());
+
+        let mut workers_to_remove_map: HashMap<String, HashMap<String, rds::Worker>> =
+            HashMap::new();
+        workers_to_remove_map.insert(stage_name.to_string(), HashMap::new());
+
+        let mut worker_groups_to_add_map: HashMap<String, Vec<rds::WorkerGroup>> = HashMap::new();
+        worker_groups_to_add_map.insert(stage_name.to_string(), Vec::new());
+
+        let mut worker_groups_to_remove_map: HashMap<String, Vec<rds::WorkerGroup>> =
+            HashMap::new();
+        worker_groups_to_remove_map.insert(stage_name.to_string(), Vec::new());
+
+        let mut current_worker_groups_per_stage: HashMap<String, HashMap<String, rds::WorkerGroup>> =
+            HashMap::new();
+        current_worker_groups_per_stage.insert(stage_name.to_string(), HashMap::new());
+
+        AutoscaleContext {
+            cluster,
+            worker_id_factory,
+            workers_to_add_map,
+            workers_to_remove_map,
+            worker_groups_to_add_map,
+            worker_groups_to_remove_map,
+            current_workers_per_stage,
+            current_worker_groups_per_stage,
+        }
+    }
+
+    /// Remove a worker and then re-add to the same stage in a single planning pass.
+    /// Exercises the production bookkeeping:
+    ///   - `remove_best_worker_fn` moves the worker from `current_workers_per_stage`
+    ///     into `workers_to_remove_map` and releases the cluster allocation.
+    ///   - `add_worker_fn` sees the to-remove map as a reuse pool, has FGD pick it, and
+    ///     moves it back into `current_workers_per_stage` without cloning.
+    ///
+    /// Post-conditions assert the full round-trip is a no-op in terms of observable state
+    /// (cluster usage, worker identity, per-stage maps, and `stage.current_workers`).
+    #[test]
+    fn test_autoscaler_bookkeeping_remove_then_reuse_in_single_pass() {
+        // 1-node cluster with 8 CPUs and 2 GPUs — enough to host exactly one 4-CPU / 0.5-GPU
+        // worker with some headroom for ScratchView to evaluate alternatives.
+        let cluster = make_cluster(1, 8, 2, false);
+
+        // The seeded worker's shape. `Worker::new` takes the worker's resource claim
+        // (`WorkerResources`) rather than a shape; FGD derives the shape from the Problem.
+        let shape = rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+            gpu_fraction: rds::FixedUtil::from_num(0.5),
+            num_cpus: rds::FixedUtil::from_num(4.0),
+        });
+        let seeded_worker = rds::Worker::new(
+            "worker-seeded".into(),
+            "stage-a".into(),
+            rds::WorkerResources {
+                node: "node0".into(),
+                cpus: rds::FixedUtil::from_num(4.0),
+                gpus: vec![rds::GpuAllocation {
+                    offset: 0,
+                    used_fraction: rds::FixedUtil::from_num(0.5),
+                }],
+            },
+        );
+
+        let mut worker_id_factory = WorkerIdFactory::new();
+        let mut c = seed_context(
+            cluster,
+            &mut worker_id_factory,
+            "stage-a",
+            seeded_worker.clone(),
+        );
+        let mut stage = make_stage_internal("stage-a", shape, 1);
+        let workload = make_workload_for_stage(&stage);
+        let mut metrics = AutoscalerOpMetrics::new();
+
+        // --- snapshot pre-state so we can assert full round-trip equivalence ---
+        let pool_before = c.cluster.used_pool();
+        assert_eq!(pool_before.cpus, 4.0);
+        assert_eq!(pool_before.gpus, 0.5);
+        assert_eq!(stage.current_workers, 1);
+
+        // (1) Remove the worker — exercises the production remove path.
+        remove_best_worker_fn(&mut stage, &workload, &mut metrics, &mut c);
+
+        // Post-remove invariants
+        assert_eq!(stage.current_workers, 0, "remove must decrement stage count");
+        let to_remove_for_stage = c
+            .workers_to_remove_map
+            .get("stage-a")
+            .expect("stage entry present");
+        assert_eq!(
+            to_remove_for_stage.len(),
+            1,
+            "worker should have moved into workers_to_remove_map"
+        );
+        assert!(
+            to_remove_for_stage.contains_key(&seeded_worker.id),
+            "to_remove_map must key by the worker's own id"
+        );
+        assert!(
+            c.current_workers_per_stage
+                .get("stage-a")
+                .expect("stage present")
+                .is_empty(),
+            "current_workers_per_stage must be drained by the remove"
+        );
+        // Remove must not speculatively populate the add map — that would cause the
+        // final `Solution` to double-count the worker (once as new, once as deleted).
+        assert!(
+            c.workers_to_add_map
+                .get("stage-a")
+                .expect("stage present")
+                .is_empty(),
+            "remove must NOT populate workers_to_add_map"
+        );
+        let pool_after_remove = c.cluster.used_pool();
+        assert_eq!(
+            pool_after_remove.cpus, 0.0,
+            "cluster CPUs must be released after remove"
+        );
+        assert_eq!(
+            pool_after_remove.gpus, 0.0,
+            "cluster GPUs must be released after remove"
+        );
+        assert_eq!(metrics.remove_calls, 1, "remove metric must be recorded");
+
+        // (2) Add a worker for the same stage — FGD should see the to-remove entry as a
+        //     reuse candidate and pick it. This exercises the production reuse bookkeeping.
+        let ok = add_worker_fn(
+            &mut stage,
+            &workload,
+            REUSE_BONUS_FORCING_REUSE,
+            &mut metrics,
+            &mut c,
+        );
+        assert!(ok, "add_worker_fn must succeed when the cluster has room");
+
+        // Post-reuse invariants: the full round-trip must be a no-op.
+        assert_eq!(
+            stage.current_workers, 1,
+            "add must increment stage count back to 1"
+        );
+        assert!(
+            c.workers_to_remove_map
+                .get("stage-a")
+                .expect("stage present")
+                .is_empty(),
+            "workers_to_remove_map must be drained by the reuse (no stale clone)"
+        );
+        let current_after = c
+            .current_workers_per_stage
+            .get("stage-a")
+            .expect("stage present");
+        assert_eq!(
+            current_after.len(),
+            1,
+            "current_workers_per_stage must have the reused worker back"
+        );
+        let restored = current_after
+            .get(&seeded_worker.id)
+            .expect("reused worker must live under its ORIGINAL id (not a freshly minted one)");
+        // Full `Worker` equality catches any field that might silently change across
+        // the remove→reuse round-trip (allocation, stage_name, or any future field).
+        assert_eq!(
+            *restored, seeded_worker,
+            "reuse must restore the original Worker in full"
+        );
+
+        // The reuse path intentionally does NOT add to workers_to_add_map — the worker was
+        // never really removed from the caller's perspective. Confirm that invariant, since
+        // leaking the worker into the add map would cause the final `Solution` to
+        // double-count it (as both new and deleted).
+        assert!(
+            c.workers_to_add_map
+                .get("stage-a")
+                .expect("stage present")
+                .is_empty(),
+            "reuse must NOT push the worker into workers_to_add_map"
+        );
+
+        // Cluster usage is back to the pre-remove snapshot.
+        let pool_after_reuse = c.cluster.used_pool();
+        assert_eq!(
+            pool_after_reuse.cpus, pool_before.cpus,
+            "cluster CPUs must be restored by the reuse re-allocation"
+        );
+        assert_eq!(
+            pool_after_reuse.gpus, pool_before.gpus,
+            "cluster GPUs must be restored by the reuse re-allocation"
+        );
+        assert_eq!(metrics.add_calls, 1, "add metric must be recorded");
+    }
+
+    /// Fresh-allocation companion: when the reuse pool is empty, `add_worker_fn` must
+    /// fall back to minting a new worker, push it into `workers_to_add_map`, and use a
+    /// freshly generated id — i.e. *not* accidentally reuse state from a prior remove.
+    /// This guards the other side of the `reused_worker_id.is_some()` branch.
+    #[test]
+    fn test_autoscaler_bookkeeping_fresh_allocation_does_not_touch_reuse_map() {
+        let cluster = make_cluster(1, 8, 2, false);
+        let shape = rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+            gpu_fraction: rds::FixedUtil::from_num(0.5),
+            num_cpus: rds::FixedUtil::from_num(4.0),
+        });
+        let seeded_worker = rds::Worker::new(
+            "worker-seeded".into(),
+            "stage-a".into(),
+            rds::WorkerResources {
+                node: "node0".into(),
+                cpus: rds::FixedUtil::from_num(4.0),
+                gpus: vec![rds::GpuAllocation {
+                    offset: 0,
+                    used_fraction: rds::FixedUtil::from_num(0.5),
+                }],
+            },
+        );
+
+        let mut worker_id_factory = WorkerIdFactory::new();
+        let mut c = seed_context(
+            cluster,
+            &mut worker_id_factory,
+            "stage-a",
+            seeded_worker.clone(),
+        );
+        let mut stage = make_stage_internal("stage-a", shape, 1);
+        let workload = make_workload_for_stage(&stage);
+        let mut metrics = AutoscalerOpMetrics::new();
+
+        let pool_before = c.cluster.used_pool();
+        assert_eq!(pool_before.cpus, 4.0, "seeded worker consumes 4 CPUs");
+        assert_eq!(pool_before.gpus, 0.5, "seeded worker consumes half a GPU");
+
+        // Reuse pool is empty for this stage — `add_worker_fn` must take the fresh path.
+        // The reuse bonus is still passed (and non-zero) to confirm it is inert when
+        // there's nothing in the reuse map.
+        let ok = add_worker_fn(
+            &mut stage,
+            &workload,
+            REUSE_BONUS_FORCING_REUSE,
+            &mut metrics,
+            &mut c,
+        );
+        assert!(ok, "fresh allocation must succeed with 4 CPUs + 1 GPU free");
+
+        assert_eq!(stage.current_workers, 2);
+        assert_eq!(metrics.add_calls, 1, "add metric must be recorded");
+
+        // The fresh path appends to `workers_to_add_map` and `current_workers_per_stage`
+        // with a NEWLY minted id — not the seeded worker's id.
+        let to_add = c.workers_to_add_map.get("stage-a").expect("stage present");
+        assert_eq!(to_add.len(), 1, "fresh add must push exactly one worker");
+        let new_worker = &to_add[0];
+        assert_ne!(
+            new_worker.id, seeded_worker.id,
+            "fresh add must use a freshly minted id, not the seeded worker's id"
+        );
+
+        let current = c
+            .current_workers_per_stage
+            .get("stage-a")
+            .expect("stage present");
+        assert_eq!(
+            current.len(),
+            2,
+            "current_workers_per_stage must contain both seeded and fresh workers"
+        );
+        assert!(current.contains_key(&seeded_worker.id));
+        assert!(current.contains_key(&new_worker.id));
+
+        // The cluster must have actually allocated the new worker's resources. Guards
+        // against a regression where the fresh path forgets to call `cluster.allocate`
+        // (which would still grow the maps but leave the cluster pool stale).
+        let pool_after = c.cluster.used_pool();
+        assert_eq!(
+            pool_after.cpus,
+            pool_before.cpus + 4.0,
+            "fresh add must allocate the new worker's CPUs on the cluster"
+        );
+        assert_eq!(
+            pool_after.gpus,
+            pool_before.gpus + 0.5,
+            "fresh add must allocate the new worker's GPU fraction on the cluster"
+        );
+
+        // The reuse map was never populated for this test, so it must remain empty.
+        assert!(
+            c.workers_to_remove_map
+                .get("stage-a")
+                .expect("stage present")
+                .is_empty(),
+            "workers_to_remove_map must remain empty on the fresh path"
+        );
+    }
 }

--- a/src/pipelines/private/scheduling/autoscaling_algorithms.rs
+++ b/src/pipelines/private/scheduling/autoscaling_algorithms.rs
@@ -2800,8 +2800,10 @@ mod tests {
             HashMap::new();
         worker_groups_to_remove_map.insert(stage_name.to_string(), Vec::new());
 
-        let mut current_worker_groups_per_stage: HashMap<String, HashMap<String, rds::WorkerGroup>> =
-            HashMap::new();
+        let mut current_worker_groups_per_stage: HashMap<
+            String,
+            HashMap<String, rds::WorkerGroup>,
+        > = HashMap::new();
         current_worker_groups_per_stage.insert(stage_name.to_string(), HashMap::new());
 
         AutoscaleContext {
@@ -2871,7 +2873,10 @@ mod tests {
         remove_best_worker_fn(&mut stage, &workload, &mut metrics, &mut c);
 
         // Post-remove invariants
-        assert_eq!(stage.current_workers, 0, "remove must decrement stage count");
+        assert_eq!(
+            stage.current_workers, 0,
+            "remove must decrement stage count"
+        );
         let to_remove_for_stage = c
             .workers_to_remove_map
             .get("stage-a")

--- a/src/pipelines/private/scheduling/autoscaling_algorithms.rs
+++ b/src/pipelines/private/scheduling/autoscaling_algorithms.rs
@@ -669,30 +669,35 @@ fn add_worker_fn(
             // Prepare a slice of reusable workers for this stage if we have pending removals
             let reusable_workers = c.workers_to_remove_map.get(&stage.name).unwrap();
             let allocation = frag::find_best_allocation_using_fragmentation_gradient_descent(
-                &mut c.cluster,
+                &c.cluster,
                 workload_estimate,
                 &stage.shape,
                 Some(reusable_workers),
                 worker_reuse_fragmentation_equivalent,
             );
             if allocation.did_allocate {
-                if let Some(reused) = allocation.reused_worker.clone() {
-                    // Reuse a previously deleted worker
+                if let Some(reused_id) = allocation.reused_worker_id {
+                    // Reuse a previously deleted worker. Move the original out of the
+                    // pending-remove map so we don't clone the whole `Worker`.
+                    let original = c
+                        .workers_to_remove_map
+                        .get_mut(&stage.name)
+                        .expect("stage exists")
+                        .remove(&reused_id)
+                        .expect("reusable worker still in workers_to_remove_map");
                     c.cluster
-                        .allocate(&reused.allocation)
+                        .allocate(&original.allocation)
                         .expect("re-allocate reused worker");
                     c.current_workers_per_stage
                         .get_mut(&stage.name)
                         .expect("stage exists")
-                        .insert(reused.id.clone(), reused.clone());
-                    c.workers_to_remove_map
-                        .get_mut(&stage.name)
-                        .expect("stage exists")
-                        .remove(&reused.id);
+                        .insert(reused_id, original);
                     stage.current_workers += 1;
                     ok = true;
-                } else if let Some(resources) = allocation.resources.clone() {
-                    // Fresh allocation
+                } else if let Some(resources) = allocation.resources {
+                    // Fresh allocation. We need the worker in two maps (active + to-add),
+                    // so one clone is unavoidable; clone the cheaper id rather than the
+                    // whole `Worker`.
                     let worker = rds::Worker::new(
                         c.worker_id_factory.make_new_id(),
                         stage.name.clone(),
@@ -701,14 +706,15 @@ fn add_worker_fn(
                     c.cluster
                         .allocate(&worker.allocation)
                         .expect("allocate worker");
-                    c.current_workers_per_stage
-                        .get_mut(&stage.name)
-                        .expect("stage exists")
-                        .insert(worker.id.clone(), worker.clone());
+                    let id_for_active = worker.id.clone();
                     c.workers_to_add_map
                         .entry(stage.name.clone())
                         .or_default()
-                        .push(worker);
+                        .push(worker.clone());
+                    c.current_workers_per_stage
+                        .get_mut(&stage.name)
+                        .expect("stage exists")
+                        .insert(id_for_active, worker);
                     stage.current_workers += 1;
                     ok = true;
                 }
@@ -758,32 +764,33 @@ fn remove_best_worker_fn(
                 .remove(&chosen_worker_id);
         }
         _ => {
-            // Get references to workers in this stage without cloning
-            let worker_map = c
+            // Choose deletion using the fragmentation heuristic. The borrow of
+            // `current_workers_per_stage` ends with the call so we can move the worker
+            // out of the same map immediately afterwards (no Worker clones).
+            let chosen_worker_id = {
+                let worker_map = c
+                    .current_workers_per_stage
+                    .get(&stage.name)
+                    .expect("stage exists");
+                frag::find_worker_to_delete_using_fragmentation_gradient_descent(
+                    &c.cluster,
+                    workload_estimate,
+                    worker_map,
+                )
+            };
+            let worker = c
                 .current_workers_per_stage
-                .get(&stage.name)
-                .expect("stage exists");
-            // Choose deletion using the fragmentation heuristic
-            let chosen_worker_id = frag::find_worker_to_delete_using_fragmentation_gradient_descent(
-                &mut c.cluster,
-                workload_estimate,
-                worker_map,
-            );
-            let worker = worker_map
-                .get(&chosen_worker_id)
-                .expect("worker exists")
-                .clone();
+                .get_mut(&stage.name)
+                .expect("stage exists")
+                .remove(&chosen_worker_id)
+                .expect("worker exists");
             c.cluster
                 .release_allocation(&worker.allocation)
                 .expect("release worker");
             c.workers_to_remove_map
                 .get_mut(&stage.name)
                 .expect("stage exists")
-                .insert(worker.id.clone(), worker.clone());
-            c.current_workers_per_stage
-                .get_mut(&stage.name)
-                .expect("stage exists")
-                .remove(&chosen_worker_id);
+                .insert(chosen_worker_id, worker);
         }
     }
 

--- a/src/pipelines/private/scheduling/fragmentation_allocation_algorithms.rs
+++ b/src/pipelines/private/scheduling/fragmentation_allocation_algorithms.rs
@@ -1035,11 +1035,7 @@ mod tests {
     }
 
     fn canonicalize_zero(value: f32) -> f32 {
-        if value == 0.0 {
-            0.0
-        } else {
-            value
-        }
+        if value == 0.0 { 0.0 } else { value }
     }
 
     // --------------------

--- a/src/pipelines/private/scheduling/fragmentation_allocation_algorithms.rs
+++ b/src/pipelines/private/scheduling/fragmentation_allocation_algorithms.rs
@@ -25,7 +25,6 @@
 //! complex algorithm. We also consider the removal of workers, which is a simple extension.
 
 use super::resources as rds;
-
 // --------------------
 // Stages and workloads
 // --------------------
@@ -100,11 +99,15 @@ impl FragmentationResult {
 }
 
 /// Result of an allocation attempt, indicating success and resource details.
+///
+/// `reused_worker_id` is set when the chosen allocation came from the `reusable_workers`
+/// map passed to FGD. Callers can look the worker up directly in their own bookkeeping
+/// (avoids cloning the entire `Worker` out of FGD for every reuse decision).
 #[derive(Debug, Clone)]
 pub struct AllocationResult {
     pub did_allocate: bool,
     pub resources: Option<rds::WorkerResources>,
-    pub reused_worker: Option<rds::Worker>,
+    pub reused_worker_id: Option<String>,
 }
 
 /// Determines if this GPU can accommodate the given worker shape requirements.
@@ -125,46 +128,28 @@ pub struct AllocationResult {
 /// # Returns
 /// True if the GPU can accommodate this shape, False otherwise
 pub fn gpu_can_be_used_to_allocate(gpu: &rds::GpuResources, shape: &rds::WorkerShape) -> bool {
+    gpu_can_be_used_to_allocate_inner(gpu.used_fraction, shape)
+}
+
+/// Same as [`gpu_can_be_used_to_allocate`] but takes the effective `used_fraction` directly,
+/// so the caller can score *what-if* allocations without mutating the GPU.
+#[inline]
+fn gpu_can_be_used_to_allocate_inner(
+    used_fraction: rds::FixedUtil,
+    shape: &rds::WorkerShape,
+) -> bool {
     match shape {
         rds::WorkerShape::CpuOnly(_) => false,
-        rds::WorkerShape::FractionalGpu(s) => {
-            gpu.used_fraction + s.gpu_fraction <= rds::FixedUtil::ONE
-        }
-        rds::WorkerShape::WholeNumberedGpu(_) => gpu.is_fully_unallocated(),
-        rds::WorkerShape::SpmdNodeMultiple(_) => gpu.is_fully_unallocated(),
-        rds::WorkerShape::SpmdSmallerThanNode(_) => gpu.is_fully_unallocated(),
+        rds::WorkerShape::FractionalGpu(s) => used_fraction + s.gpu_fraction <= rds::FixedUtil::ONE,
+        rds::WorkerShape::WholeNumberedGpu(_)
+        | rds::WorkerShape::SpmdNodeMultiple(_)
+        | rds::WorkerShape::SpmdSmallerThanNode(_) => used_fraction == rds::FixedUtil::ZERO,
     }
 }
 
 // --------------------
 // Node helpers
 // --------------------
-
-/// Counts number of GPUs on node that can accommodate given shape.
-///
-/// # Arguments
-/// * `shape` - WorkerShape describing resource requirements
-///
-/// # Returns
-/// Number of GPUs that can be used for this shape
-fn number_of_gpus_which_can_be_used_for_shape(
-    node_resources: &rds::NodeResources,
-    shape: &rds::WorkerShape,
-) -> usize {
-    node_resources
-        .gpus
-        .iter()
-        .filter(|g| gpu_can_be_used_to_allocate(g, shape))
-        .count()
-}
-
-fn num_fully_unallocated_gpus(node_resources: &rds::NodeResources) -> usize {
-    node_resources
-        .gpus
-        .iter()
-        .filter(|g| g.is_fully_unallocated())
-        .count()
-}
 
 /// Determines if node has sufficient resources for given shape.
 ///
@@ -177,8 +162,13 @@ fn num_fully_unallocated_gpus(node_resources: &rds::NodeResources) -> usize {
 /// # Returns
 /// True if node can accommodate shape, False otherwise
 pub fn node_can_allocate(node_resources: &rds::NodeResources, shape: &rds::WorkerShape) -> bool {
-    // CPU check
-    let needed_cpus = match shape {
+    ScratchView::from_node(node_resources).can_allocate(shape)
+}
+
+/// CPU resources required by `shape` on a single node.
+#[inline]
+fn cpus_needed_for_shape(shape: &rds::WorkerShape) -> rds::FixedUtil {
+    match shape {
         rds::WorkerShape::CpuOnly(s) => s.num_cpus,
         rds::WorkerShape::FractionalGpu(s) => s.num_cpus,
         rds::WorkerShape::WholeNumberedGpu(s) => s.num_cpus * rds::FixedUtil::from_num(s.num_gpus),
@@ -186,27 +176,6 @@ pub fn node_can_allocate(node_resources: &rds::NodeResources, shape: &rds::Worke
             s.num_cpus_per_actor * rds::FixedUtil::from_num(s.num_gpu_actors_in_group)
         }
         rds::WorkerShape::SpmdNodeMultiple(s) => s.num_cpus_needed_per_node(),
-    };
-
-    if node_resources.used_cpus + needed_cpus > node_resources.total_cpus {
-        return false;
-    }
-
-    match shape {
-        rds::WorkerShape::CpuOnly(_) => true,
-        rds::WorkerShape::FractionalGpu(_) => {
-            number_of_gpus_which_can_be_used_for_shape(node_resources, shape) > 0
-        }
-        rds::WorkerShape::WholeNumberedGpu(s) => {
-            num_fully_unallocated_gpus(node_resources) >= s.num_gpus as usize
-        }
-        rds::WorkerShape::SpmdSmallerThanNode(s) => {
-            num_fully_unallocated_gpus(node_resources) >= s.num_gpu_actors_in_group as usize
-        }
-        rds::WorkerShape::SpmdNodeMultiple(s) => {
-            node_resources.num_gpus() == s.num_gpus_in_node as usize
-                && node_resources.all_gpus_fully_unallocated()
-        }
     }
 }
 
@@ -325,51 +294,178 @@ pub fn find_possible_allocations_on_node(
     }
 }
 
-/// Calculates amount of GPU resources that cannot be allocated to a specific shape.
+/// A side-effect-free view of a node with overlayed CPU / per-GPU usage.
+///
+/// FGD scoring is hot — it evaluates many candidate allocations per node and previously did so
+/// by mutating the cluster (`allocate` then `release`) just to peek at fragmentation. That
+/// pattern made parallelism impossible. `ScratchView` captures the *effective* state we want
+/// to score against so the entire candidate evaluation can run on `&NodeResources`.
+///
+/// The `effective_used` slice is parallel to `node.gpus` (same length, same offsets). The
+/// buffer is owned so the FGD inner loop can reuse it across many candidates on the same
+/// node without per-candidate allocation.
+struct ScratchView<'a> {
+    node: &'a rds::NodeResources,
+    effective_used: Vec<rds::FixedUtil>,
+    effective_used_cpus: rds::FixedUtil,
+}
+
+impl<'a> ScratchView<'a> {
+    /// Build a view of `node` with no overlay applied.
+    #[inline]
+    fn from_node(node: &'a rds::NodeResources) -> Self {
+        Self {
+            node,
+            effective_used: node.gpus.iter().map(|g| g.used_fraction).collect(),
+            effective_used_cpus: node.used_cpus,
+        }
+    }
+
+    /// Resets the overlay so the view reflects the underlying node's current state.
+    #[inline]
+    fn reset(&mut self) {
+        for (slot, gpu) in self.effective_used.iter_mut().zip(self.node.gpus.iter()) {
+            *slot = gpu.used_fraction;
+        }
+        self.effective_used_cpus = self.node.used_cpus;
+    }
+
+    /// Applies a hypothetical allocation on top of the current overlay.
+    #[inline]
+    fn apply_allocate(&mut self, alloc: &rds::WorkerResources) {
+        self.effective_used_cpus += alloc.cpus;
+        for gpu_alloc in &alloc.gpus {
+            self.effective_used[gpu_alloc.offset] += gpu_alloc.used_fraction;
+        }
+    }
+
+    /// Applies a hypothetical release on top of the current overlay.
+    #[inline]
+    fn apply_release(&mut self, alloc: &rds::WorkerResources) {
+        self.effective_used_cpus -= alloc.cpus;
+        for gpu_alloc in &alloc.gpus {
+            self.effective_used[gpu_alloc.offset] -= gpu_alloc.used_fraction;
+        }
+    }
+
+    /// Resets and re-applies an allocate overlay; returns the post-allocation fragmentation.
+    /// The overlay is left in the post-allocation state so callers can read tiebreakers
+    /// (e.g. [`ScratchView::free_pool_total_num`]) without re-doing the work.
+    #[inline]
+    fn score_after_allocate(&mut self, alloc: &rds::WorkerResources, workload: &Workload) -> f32 {
+        self.reset();
+        self.apply_allocate(alloc);
+        self.estimate_fragmentation(workload)
+    }
+
+    /// Same as [`score_after_allocate`] but for the deletion path.
+    #[inline]
+    fn score_after_release(&mut self, alloc: &rds::WorkerResources, workload: &Workload) -> f32 {
+        self.reset();
+        self.apply_release(alloc);
+        self.estimate_fragmentation(workload)
+    }
+
+    /// `true` iff a hypothetical worker of `shape` could fit on top of the current effective state.
+    fn can_allocate(&self, shape: &rds::WorkerShape) -> bool {
+        if self.effective_used_cpus + cpus_needed_for_shape(shape) > self.node.total_cpus {
+            return false;
+        }
+        match shape {
+            rds::WorkerShape::CpuOnly(_) => true,
+            rds::WorkerShape::FractionalGpu(_) => self
+                .effective_used
+                .iter()
+                .any(|u| gpu_can_be_used_to_allocate_inner(*u, shape)),
+            rds::WorkerShape::WholeNumberedGpu(s) => {
+                self.count_fully_unallocated_gpus() >= s.num_gpus as usize
+            }
+            rds::WorkerShape::SpmdSmallerThanNode(s) => {
+                self.count_fully_unallocated_gpus() >= s.num_gpu_actors_in_group as usize
+            }
+            rds::WorkerShape::SpmdNodeMultiple(s) => {
+                self.node.gpus.len() == s.num_gpus_in_node as usize
+                    && self
+                        .effective_used
+                        .iter()
+                        .all(|u| *u == rds::FixedUtil::ZERO)
+            }
+        }
+    }
+
+    #[inline]
+    fn count_fully_unallocated_gpus(&self) -> usize {
+        self.effective_used
+            .iter()
+            .filter(|u| **u == rds::FixedUtil::ZERO)
+            .count()
+    }
+
+    /// Sum of `(1 - used)` across all GPUs.
+    #[inline]
+    fn total_available_gpus(&self) -> f32 {
+        self.effective_used
+            .iter()
+            .map(|u| 1.0 - u.to_num::<f32>())
+            .sum()
+    }
+
+    /// `f32` mirror of `NodeResources::free_pool().total_num()` (free CPUs + free GPU compute).
+    #[inline]
+    fn free_pool_total_num(&self) -> f32 {
+        let free_cpus = (self.node.total_cpus - self.effective_used_cpus).to_num::<f32>();
+        free_cpus + self.total_available_gpus()
+    }
+
+    /// `f32` mirror of `NodeResources::used_pool().total_num()` (used CPUs + used GPU fraction).
+    #[inline]
+    fn used_pool_total_num(&self) -> f32 {
+        let used_cpus = self.effective_used_cpus.to_num::<f32>();
+        let used_gpus: f32 = self.effective_used.iter().map(|u| u.to_num::<f32>()).sum();
+        used_cpus + used_gpus
+    }
+
+    /// Calculates GPU resources that cannot be allocated to `shape` given the effective state.
+    fn unallocatable_gpus_for_shape(&self, shape: &rds::WorkerShape) -> f32 {
+        let total_available_gpus = self.total_available_gpus();
+
+        if let rds::WorkerShape::CpuOnly(_) = shape {
+            return total_available_gpus;
+        }
+        if !self.can_allocate(shape) {
+            return total_available_gpus;
+        }
+
+        let mut out = 0.0;
+        for &used in &self.effective_used {
+            if !gpu_can_be_used_to_allocate_inner(used, shape) {
+                out += 1.0 - used.to_num::<f32>();
+            }
+        }
+        out
+    }
+
+    /// Estimated fragmentation across the whole workload, weighted by stage frequency.
+    fn estimate_fragmentation(&self, workload: &Workload) -> f32 {
+        let mut out = 0.0;
+        for stage in &workload.stages {
+            out += stage.frequency * self.unallocatable_gpus_for_shape(&stage.shape);
+        }
+        out
+    }
+}
+
+/// Calculates GPU resources that cannot be allocated to a specific shape on a node.
 ///
 /// This implements the task-level fragmentation measure F_n(m) described in Section 3.2
-/// of the paper. It measures how many GPU resources cannot be allocated to a given
-/// task shape due to various constraints.
-///
-/// # Arguments
-/// * `shape` - WorkerShape describing resource requirements
-///
-/// # Returns
-/// Amount of GPU resources that cannot be allocated to this shape.
-/// A higher value indicates more fragmentation from this shape's perspective.
+/// of the paper. Thin wrapper over the [`ScratchView`] machinery so tests retain a stable
+/// function-style entry point.
+#[cfg(test)]
 fn calculate_unallocatable_gpus_fragment_for_shape_on_node(
     node_resources: &rds::NodeResources,
     shape: &rds::WorkerShape,
 ) -> f32 {
-    // Calculate total GPU compute resources available on this node
-    let total_available_gpus = node_resources
-        .gpus
-        .iter()
-        .map(|g| 1.0 - g.used_fraction.to_num::<f32>())
-        .sum();
-
-    // Case 1: Task requests no GPU compute resources
-    // All available GPU resources are "fragmented" since they can't be used by this task type
-    if let rds::WorkerShape::CpuOnly(_) = shape {
-        return total_available_gpus;
-    }
-
-    // Case 2: Shape cannot be allocated to the node at all
-    // All available GPU resources are fragmented since the task can't be satisfied
-    if !node_can_allocate(node_resources, shape) {
-        return total_available_gpus;
-    }
-
-    // Case 3: Shape can be allocated, but some GPUs may be unusable
-    // Count GPU resources that cannot contribute to allocating this shape
-    let mut out = 0.0;
-    for node_gpu in &node_resources.gpus {
-        // If this GPU cannot contribute to the allocation, its resources are fragmented
-        if !gpu_can_be_used_to_allocate(node_gpu, shape) {
-            out += 1.0 - node_gpu.used_fraction.to_num::<f32>();
-        }
-    }
-    out
+    ScratchView::from_node(node_resources).unallocatable_gpus_for_shape(shape)
 }
 
 /// Estimates overall fragmentation from perspective of entire workload.
@@ -387,16 +483,7 @@ pub fn estimate_fragmentation_on_node(
     node_resources: &rds::NodeResources,
     workload: &Workload,
 ) -> f32 {
-    let mut out = 0.0;
-    // Calculate weighted fragmentation across all workload stages
-    for stage in &workload.stages {
-        // Get fragmentation for this specific task type
-        let unallocatable_gpus =
-            calculate_unallocatable_gpus_fragment_for_shape_on_node(node_resources, &stage.shape);
-        // Weight by how frequently this task type occurs
-        out += stage.frequency * unallocatable_gpus;
-    }
-    out
+    ScratchView::from_node(node_resources).estimate_fragmentation(workload)
 }
 
 // --------------------
@@ -424,6 +511,13 @@ pub fn estimate_fragmentation_on_cluster(
 /// in Section 4.2 of the paper. It tries all possible allocations and chooses
 /// the one that causes the minimum increase in fragmentation.
 ///
+/// Optimization notes:
+/// * The cluster is borrowed immutably — candidate scoring is pure (uses [`ScratchView`]
+///   to evaluate "what-if" overlays without mutating any node), which avoids the
+///   redundant allocate/release round-trips the original implementation performed.
+/// * Candidates are reduced with a streaming "best so far" rather than collected into a
+///   `Vec<FragmentationResult>` and post-sorted, so we don't allocate per-candidate.
+///
 /// # Arguments
 /// * `cluster` - Cluster resource helper
 /// * `workload` - Workload object describing expected task distribution
@@ -433,126 +527,115 @@ pub fn estimate_fragmentation_on_cluster(
 /// * `worker_reuse_fragmentation_equivalent` - A reward for re-using workers.
 ///
 /// # Returns
-/// WorkerResources describing best allocation, or None if no allocation possible
+/// `AllocationResult` describing the chosen allocation. If no allocation is possible
+/// `did_allocate` is `false` and the other fields are `None`.
 pub fn find_best_allocation_using_fragmentation_gradient_descent(
-    cluster: &mut rds::ClusterResources,
+    cluster: &rds::ClusterResources,
     workload: &Workload,
     shape: &rds::WorkerShape,
     reusable_workers: Option<&std::collections::HashMap<String, rds::Worker>>,
     worker_reuse_fragmentation_equivalent: f32,
 ) -> AllocationResult {
-    // Shape::SpmdNodeMultiple is not implemented. This code path should not be reached.
+    // SpmdNodeMultiple has its own dedicated allocation function and should never reach here.
     if let rds::WorkerShape::SpmdNodeMultiple(_) = shape {
         panic!("SpmdNodeMultiple is not implemented. This code path should not be reached.");
     }
 
-    // Store all possible allocation options with their fragmentation impact
-    let mut results: Vec<FragmentationResult> = Vec::new();
+    /// A streaming "best candidate" for the allocate path. Cost is `(primary, secondary)`
+    /// compared lexicographically; lower is better.
+    struct Candidate {
+        primary: f32,
+        secondary: f32,
+        worker_allocation: rds::WorkerResources,
+        reused_worker_id: Option<String>,
+    }
 
-    // First, try reusing recently removed workers to avoid allocation thrashing
-    // This helps prevent oscillation between creating and destroying workers
-    if let Some(reuse_map) = reusable_workers {
+    #[inline]
+    fn pick_better(a: Candidate, b: Candidate) -> Candidate {
+        if (a.primary, a.secondary) <= (b.primary, b.secondary) {
+            a
+        } else {
+            b
+        }
+    }
+
+    #[inline]
+    fn merge(a: Option<Candidate>, b: Option<Candidate>) -> Option<Candidate> {
+        match (a, b) {
+            (None, x) | (x, None) => x,
+            (Some(a), Some(b)) => Some(pick_better(a, b)),
+        }
+    }
+
+    // ---------- reuse path (sequential; reuse_map is small) ----------
+    let reuse_best: Option<Candidate> = reusable_workers.and_then(|reuse_map| {
+        let mut best: Option<Candidate> = None;
         for worker in reuse_map.values() {
-            let node = cluster
-                .nodes
-                .get_mut(&worker.allocation.node)
-                .expect("node");
-            // Check if this worker's allocation is still feasible
+            let node = match cluster.nodes.get(&worker.allocation.node) {
+                Some(n) => n,
+                None => continue,
+            };
             if !node.can_allocate(&worker.allocation) {
                 continue;
             }
 
-            // Calculate fragmentation impact of reusing this worker
-            let current_frag = estimate_fragmentation_on_node(node, workload);
+            // `score_after_allocate` leaves the overlay in the post-allocation state, so
+            // we can read the tiebreaker (`used_pool_total_num`) directly without redoing
+            // the work. The "before" frag is computed once per reuse candidate (matches
+            // the original code's per-candidate pattern, which was correct here).
+            let mut sv = ScratchView::from_node(node);
+            let before = sv.estimate_fragmentation(workload);
+            let after = sv.score_after_allocate(&worker.allocation, workload);
+            let remaining = sv.used_pool_total_num();
 
-            node.allocate(&worker.allocation).expect("allocate");
-            let new_frag = estimate_fragmentation_on_node(node, workload);
-            let new_remaining_resources = node.used_pool().total_num();
-            node.release_allocation(&worker.allocation);
-
-            // Record this reuse option for comparison
-            results.push(FragmentationResult {
-                fragmentation_before: current_frag,
-                fragmentation_after: new_frag,
-                node_remaining_resources: new_remaining_resources,
+            let primary = (after - before) - worker_reuse_fragmentation_equivalent;
+            let cand = Candidate {
+                primary,
+                secondary: -remaining,
                 worker_allocation: worker.allocation.clone(),
-                maybe_reused_worker: Some(worker.clone()),
-            });
+                reused_worker_id: Some(worker.id.clone()),
+            };
+            best = merge(best, Some(cand));
         }
-    }
+        best
+    });
 
-    // Now explore all possible fresh allocations across the cluster
-    for (node_id, node) in &mut cluster.nodes {
-        // Skip nodes that cannot accommodate this shape
-        if !node_can_allocate(node, shape) {
-            continue;
+    // ---------- fresh path ----------
+    let fresh_best: Option<Candidate> = {
+        let mut best: Option<Candidate> = None;
+        for (node_id, node) in &cluster.nodes {
+            if !node_can_allocate(node, shape) {
+                continue;
+            }
+            let mut sv = ScratchView::from_node(node);
+            let before = sv.estimate_fragmentation(workload);
+
+            for allocation in find_possible_allocations_on_node(node, shape, node_id) {
+                let after = sv.score_after_allocate(&allocation, workload);
+                let remaining = sv.free_pool_total_num();
+                let cand = Candidate {
+                    primary: after - before,
+                    secondary: -remaining,
+                    worker_allocation: allocation,
+                    reused_worker_id: None,
+                };
+                best = merge(best, Some(cand));
+            }
         }
+        best
+    };
 
-        // Calculate current fragmentation level for this node
-        let current_frag = estimate_fragmentation_on_node(node, workload);
-
-        // Find all possible ways to allocate this shape on this node
-        let possible_allocations = find_possible_allocations_on_node(node, shape, node_id);
-
-        // Evaluate the fragmentation impact of each possible allocation
-        for allocation in possible_allocations {
-            node.allocate(&allocation).expect("allocate");
-            let new_frag = estimate_fragmentation_on_node(node, workload);
-            let new_remaining_resources = node.free_pool().total_num();
-            node.release_allocation(&allocation);
-            // Record this allocation option for comparison
-            results.push(FragmentationResult {
-                fragmentation_before: current_frag,
-                fragmentation_after: new_frag,
-                node_remaining_resources: new_remaining_resources,
-                worker_allocation: allocation,
-                maybe_reused_worker: None, // This is a fresh allocation
-            });
-        }
-    }
-
-    // Return failure if no allocations are possible
-    if results.is_empty() {
-        return AllocationResult {
+    match merge(reuse_best, fresh_best) {
+        None => AllocationResult {
             did_allocate: false,
             resources: None,
-            reused_worker: None,
-        };
-    }
-
-    /// Cost function for comparing allocation options.
-    ///
-    /// Returns a tuple (fragmentation_change, -remaining_resources) for lexicographic ordering.
-    /// Lower fragmentation change is preferred, with more remaining resources as tiebreaker.
-    fn cost(x: &FragmentationResult, worker_reuse_fragmentation_equivalent: f32) -> (f32, f32) {
-        let mut fragmentation_change = x.fragmentation_change();
-
-        // Apply reuse bonus: reusing workers gets an equivalent fragmentation reduction
-        // This helps prevent thrashing between allocation and deallocation
-        if x.is_reused_worker() {
-            fragmentation_change -= worker_reuse_fragmentation_equivalent;
-        }
-
-        // Return (primary_cost, secondary_cost) where:
-        // - primary_cost: fragmentation change (lower is better)
-        // - secondary_cost: negative remaining resources (higher remaining is better)
-        (fragmentation_change, -x.node_remaining_resources)
-    }
-
-    // Select the allocation option with the best cost (minimum fragmentation increase)
-    let best = results
-        .into_iter()
-        .min_by(|a, b| {
-            let ca = cost(a, worker_reuse_fragmentation_equivalent);
-            let cb = cost(b, worker_reuse_fragmentation_equivalent);
-            ca.partial_cmp(&cb).unwrap_or(std::cmp::Ordering::Equal)
-        })
-        .unwrap();
-
-    AllocationResult {
-        did_allocate: true,
-        resources: Some(best.worker_allocation.clone()),
-        reused_worker: best.maybe_reused_worker.clone(),
+            reused_worker_id: None,
+        },
+        Some(best) => AllocationResult {
+            did_allocate: true,
+            resources: Some(best.worker_allocation),
+            reused_worker_id: best.reused_worker_id,
+        },
     }
 }
 
@@ -570,60 +653,67 @@ pub fn find_best_allocation_using_fragmentation_gradient_descent(
 /// # Returns
 /// Worker that should be removed to minimize fragmentation impact
 pub fn find_worker_to_delete_using_fragmentation_gradient_descent(
-    cluster: &mut rds::ClusterResources,
+    cluster: &rds::ClusterResources,
     workload: &Workload,
     potential_workers: &std::collections::HashMap<String, rds::Worker>,
 ) -> String {
     assert!(!potential_workers.is_empty());
 
-    #[derive(Debug, Clone)]
-    struct CandidateCost {
+    // Group candidate workers by their host node. The "before" fragmentation only depends
+    // on the node's current state, so this lets us compute it once per node instead of
+    // once per worker — a sizeable win when a stage has many workers concentrated on a
+    // few nodes.
+    let mut by_node: std::collections::HashMap<&str, Vec<&rds::Worker>> =
+        std::collections::HashMap::new();
+    for w in potential_workers.values() {
+        by_node
+            .entry(w.allocation.node.as_str())
+            .or_default()
+            .push(w);
+    }
+
+    /// Lifetime `'a` ties the chosen id back to `potential_workers` so we don't allocate a
+    /// `String` for every losing candidate — only the winner is converted to `String` at
+    /// the very end of the call.
+    struct Candidate<'a> {
         frag_delta: f32,
-        used_resources_before: f32,
-        worker_id: String,
+        // Negated so smaller-is-better matches the (primary, secondary) tuple convention
+        // and lets the reduce step use a simple `<=` comparison.
+        neg_used_before: f32,
+        worker_id: &'a str,
     }
 
-    let mut changes: Vec<CandidateCost> = Vec::new();
-
-    // Evaluate the fragmentation impact of removing each candidate worker
-    for (worker_id, worker) in potential_workers.iter() {
-        let node = cluster
-            .nodes
-            .get_mut(&worker.allocation.node)
-            .expect("node");
-        // Fragmentation before on this node
-        let frag_before = estimate_fragmentation_on_node(node, workload);
-        let used_resources_before = node.used_pool().total_num();
-
-        // Simulate releasing the worker on a cloned NodeResources
-        node.release_allocation(&worker.allocation);
-        // Fragmentation after on this node
-        let frag_after = estimate_fragmentation_on_node(node, workload);
-        // Re-allocate the worker so that we do not actually mutate the cluster
-        node.allocate(&worker.allocation).expect("allocate");
-
-        changes.push(CandidateCost {
-            frag_delta: frag_after - frag_before,
-            used_resources_before,
-            worker_id: worker_id.clone(),
-        });
+    #[inline]
+    fn pick_better<'a>(a: Candidate<'a>, b: Candidate<'a>) -> Candidate<'a> {
+        if (a.frag_delta, a.neg_used_before) <= (b.frag_delta, b.neg_used_before) {
+            a
+        } else {
+            b
+        }
     }
 
-    log::trace!("changes: {:?}", changes);
-    // Select the worker whose removal results in the lowest cluster fragmentation
-    // If multiple workers result in the same fragmentation, prefer removing the one
-    // from the highest-utilized node.
-    changes
-        .into_iter()
-        .min_by(|a, b| {
-            // Cost tuples: (frag_delta, -remaining_resources_after)
-            // Lower delta is preferred; if equal, prefer higher-utilized nodes.
-            let ka = (a.frag_delta, -a.used_resources_before);
-            let kb = (b.frag_delta, -b.used_resources_before);
-            ka.partial_cmp(&kb).unwrap_or(std::cmp::Ordering::Equal)
-        })
-        .expect("non-empty")
-        .worker_id
+    let mut best: Option<Candidate<'_>> = None;
+    for (name, workers) in &by_node {
+        let node = cluster.nodes.get(*name).expect("node");
+        let mut sv = ScratchView::from_node(node);
+        let frag_before = sv.estimate_fragmentation(workload);
+        let neg_used_before = -sv.used_pool_total_num();
+
+        for w in workers {
+            let frag_after = sv.score_after_release(&w.allocation, workload);
+            let cand = Candidate {
+                frag_delta: frag_after - frag_before,
+                neg_used_before,
+                worker_id: &w.id,
+            };
+            best = match best {
+                None => Some(cand),
+                Some(b) => Some(pick_better(b, cand)),
+            };
+        }
+    }
+
+    best.expect("non-empty").worker_id.to_string()
 }
 
 #[derive(Debug, Clone)]
@@ -1065,7 +1155,7 @@ mod tests {
     #[test]
     fn test_allocation_success_fractional_gpu() {
         // Test successful allocation of fractional GPU workload
-        let mut cluster = uniform_cluster(1, 16.0, 2);
+        let cluster = uniform_cluster(1, 16.0, 2);
         let workload = simple_workload(&cluster);
 
         let shape = rds::Resources {
@@ -1077,11 +1167,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
-            &workload,
-            &shape,
-            None,
-            0.0, // No reuse bonus
+            &cluster, &workload, &shape, None, 0.0, // No reuse bonus
         );
 
         assert!(result.did_allocate, "Should successfully allocate");
@@ -1098,7 +1184,7 @@ mod tests {
     #[test]
     fn test_allocation_success_whole_gpu() {
         // Test successful allocation of whole GPU workload
-        let mut cluster = uniform_cluster(1, 16.0, 2);
+        let cluster = uniform_cluster(1, 16.0, 2);
         let workload = simple_workload(&cluster);
 
         let shape = rds::Resources {
@@ -1110,11 +1196,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
-            &workload,
-            &shape,
-            None,
-            0.0,
+            &cluster, &workload, &shape, None, 0.0,
         );
 
         assert!(result.did_allocate, "Should successfully allocate");
@@ -1127,7 +1209,7 @@ mod tests {
     #[test]
     fn test_allocation_success_cpu_only() {
         // Test successful allocation of CPU-only workload
-        let mut cluster = uniform_cluster(1, 16.0, 2);
+        let cluster = uniform_cluster(1, 16.0, 2);
         let workload = simple_workload(&cluster);
 
         let shape = rds::Resources {
@@ -1139,11 +1221,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
-            &workload,
-            &shape,
-            None,
-            0.0,
+            &cluster, &workload, &shape, None, 0.0,
         );
 
         assert!(result.did_allocate, "Should successfully allocate");
@@ -1175,11 +1253,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
-            &workload,
-            &shape,
-            None,
-            0.0,
+            &cluster, &workload, &shape, None, 0.0,
         );
 
         assert!(!result.did_allocate, "Should fail to allocate");
@@ -1189,7 +1263,7 @@ mod tests {
     #[test]
     fn test_allocation_prefers_lower_fragmentation() {
         // Test that allocation chooses the option with lower fragmentation impact
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage("node-0", 0.0, 16.0, vec![gpu_with_usage(0, 0.3)]), // 0.7 available
             node_with_usage("node-1", 0.0, 16.0, vec![gpu_with_usage(0, 0.0)]), // 1.0 available
         ]);
@@ -1229,11 +1303,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
-            &workload,
-            &shape,
-            None,
-            0.0,
+            &cluster, &workload, &shape, None, 0.0,
         );
 
         let allocation = result.resources.unwrap();
@@ -1245,7 +1315,7 @@ mod tests {
     #[test]
     fn test_worker_reuse_functionality() {
         // Test that worker reuse works correctly and gets preference
-        let mut cluster = uniform_cluster(1, 16.0, 2);
+        let cluster = uniform_cluster(1, 16.0, 2);
         let workload = simple_workload(&cluster);
 
         // Create a reusable worker
@@ -1262,7 +1332,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &shape,
             Some(&reuse_map),
@@ -1270,9 +1340,9 @@ mod tests {
         );
 
         assert!(result.did_allocate, "Should successfully allocate");
-        assert!(result.reused_worker.is_some(), "Should reuse the worker");
-        let reused = result.reused_worker.unwrap();
-        assert_eq!(reused.id, "reusable");
+        assert!(result.reused_worker_id.is_some(), "Should reuse the worker");
+        let reused_id = result.reused_worker_id.unwrap();
+        assert_eq!(reused_id, "reusable");
     }
 
     #[test]
@@ -1300,7 +1370,7 @@ mod tests {
 
         // Without reuse bonus, should prefer fresh node
         let result_no_bonus = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &shape,
             Some(&reuse_map),
@@ -1309,7 +1379,7 @@ mod tests {
 
         // With significant reuse bonus, should prefer reuse
         let result_with_bonus = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &shape,
             Some(&reuse_map),
@@ -1317,8 +1387,8 @@ mod tests {
         );
 
         // The behavior should be different based on reuse bonus
-        let no_bonus_reused = result_no_bonus.reused_worker.is_some();
-        let with_bonus_reused = result_with_bonus.reused_worker.is_some();
+        let no_bonus_reused = result_no_bonus.reused_worker_id.is_some();
+        let with_bonus_reused = result_with_bonus.reused_worker_id.is_some();
 
         // With a large bonus, reuse should be more likely
         assert!(
@@ -1367,7 +1437,7 @@ mod tests {
             workers.into_iter().map(|w| (w.id.clone(), w)).collect();
 
         let to_delete = find_worker_to_delete_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &worker_map,
         );
@@ -1398,7 +1468,7 @@ mod tests {
             workers.into_iter().map(|w| (w.id.clone(), w)).collect();
 
         let to_delete = find_worker_to_delete_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &worker_map,
         );
@@ -1533,7 +1603,7 @@ mod tests {
     #[test]
     fn test_allocation_with_no_available_nodes() {
         // Test allocation when no nodes can satisfy the request
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage("node-0", 15.0, 16.0, vec![gpu_with_usage(0, 1.0)]), // Almost full
             node_with_usage("node-1", 14.0, 16.0, vec![gpu_with_usage(0, 0.9)]), // Almost full
         ]);
@@ -1548,7 +1618,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &large_shape,
             None,
@@ -1560,7 +1630,7 @@ mod tests {
             "Should fail when no nodes can satisfy request"
         );
         assert!(result.resources.is_none());
-        assert!(result.reused_worker.is_none());
+        assert!(result.reused_worker_id.is_none());
     }
 
     #[test]
@@ -1580,7 +1650,7 @@ mod tests {
     #[test]
     fn test_allocation_prefers_less_utilized_nodes() {
         // Test that allocation prefers nodes with more available resources
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage("node-0", 12.0, 16.0, vec![fresh_gpu(0)]), // High CPU usage
             node_with_usage("node-1", 2.0, 16.0, vec![fresh_gpu(0)]),  // Low CPU usage
         ]);
@@ -1595,11 +1665,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
-            &workload,
-            &shape,
-            None,
-            0.0,
+            &cluster, &workload, &shape, None, 0.0,
         );
 
         let allocation = result.resources.unwrap();
@@ -1616,7 +1682,7 @@ mod tests {
         init();
 
         // Test fragmentation decisions with very small fractional GPU requirements
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage(
                 "node-0",
                 0.0,
@@ -1672,7 +1738,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &tiny_shape,
             None,
@@ -1693,7 +1759,7 @@ mod tests {
         init();
 
         // Test with shapes that require most of a GPU but not all
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage(
                 "node-0",
                 0.0,
@@ -1749,7 +1815,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &large_frac_shape,
             None,
@@ -1816,7 +1882,7 @@ mod tests {
             workers.into_iter().map(|w| (w.id.clone(), w)).collect();
 
         let to_delete = find_worker_to_delete_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &worker_map,
         );
@@ -1834,7 +1900,7 @@ mod tests {
         init();
 
         // Test allocation of multi-GPU shapes when cluster is fragmented
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage(
                 "node-0",
                 0.0,
@@ -1891,7 +1957,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &multi_gpu_shape,
             None,
@@ -1916,7 +1982,7 @@ mod tests {
         init();
 
         // Test allocation decisions with workloads that have very different CPU/GPU ratios
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage("cpu-heavy", 8.0, 64.0, vec![gpu_with_usage(0, 0.0)]), // Lots of CPU available
             node_with_usage("gpu-heavy", 60.0, 64.0, vec![gpu_with_usage(0, 0.0)]), // Little CPU available
         ]);
@@ -1956,7 +2022,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &cpu_workload,
             &cpu_shape,
             None,
@@ -1975,7 +2041,7 @@ mod tests {
         init();
 
         // Test SPMD allocation that uses part of a node
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage(
                 "node-0",
                 0.0,
@@ -2033,7 +2099,7 @@ mod tests {
         });
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &spmd_shape,
             None,
@@ -2058,7 +2124,7 @@ mod tests {
         init();
 
         // Test with extremely skewed workload frequencies
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage(
                 "node-0",
                 0.0,
@@ -2114,7 +2180,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &skewed_workload,
             &tiny_shape,
             None,
@@ -2137,7 +2203,7 @@ mod tests {
     #[test]
     fn test_multi_gpu_allocation() {
         // Test allocation of multi-GPU workloads
-        let mut cluster = uniform_cluster(1, 32.0, 4);
+        let cluster = uniform_cluster(1, 32.0, 4);
         let workload = simple_workload(&cluster);
 
         let multi_gpu_shape = rds::Resources {
@@ -2149,7 +2215,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &multi_gpu_shape,
             None,
@@ -2301,7 +2367,7 @@ mod tests {
 
         // Use the fragmentation gradient descent algorithm
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &spmd_shape,
             None,
@@ -2355,7 +2421,7 @@ mod tests {
 
         // Try to allocate another 2-GPU SPMD task
         let result2 = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &spmd_shape,
             None,
@@ -2447,11 +2513,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
-            &workload,
-            &new_shape,
-            None,
-            0.0,
+            &cluster, &workload, &new_shape, None, 0.0,
         );
 
         assert!(
@@ -2481,7 +2543,7 @@ mod tests {
         init();
 
         // Test that worker reuse considers fragmentation impact
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage(
                 "node-0",
                 0.0,
@@ -2545,7 +2607,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &shape,
             Some(&reuse_map),
@@ -2557,9 +2619,9 @@ mod tests {
             "Should allocate with reuse consideration"
         );
 
-        if let Some(reused) = result.reused_worker {
+        if let Some(reused_id) = result.reused_worker_id {
             // Should prefer reusing the fragmented worker to avoid further fragmenting fresh GPUs
-            assert_eq!(reused.id, "fragmented");
+            assert_eq!(reused_id, "fragmented");
         }
     }
 
@@ -2598,7 +2660,7 @@ mod tests {
             workers.into_iter().map(|w| (w.id.clone(), w)).collect();
 
         let to_delete = find_worker_to_delete_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &worker_map,
         );
@@ -2612,7 +2674,7 @@ mod tests {
         init();
 
         // Test allocation decisions when GPUs are nearly full
-        let mut cluster = cluster_from_nodes(vec![
+        let cluster = cluster_from_nodes(vec![
             node_with_usage(
                 "node-0",
                 0.0,
@@ -2656,7 +2718,7 @@ mod tests {
         .unwrap();
 
         let result = find_best_allocation_using_fragmentation_gradient_descent(
-            &mut cluster,
+            &cluster,
             &workload,
             &tiny_shape,
             None,

--- a/src/pipelines/private/scheduling/fragmentation_allocation_algorithms.rs
+++ b/src/pipelines/private/scheduling/fragmentation_allocation_algorithms.rs
@@ -947,6 +947,101 @@ mod tests {
         assert_float_eq(actual, expected, 1e-4); // More lenient tolerance for FixedUtil precision
     }
 
+    fn manual_cpus_needed_for_shape(shape: &rds::WorkerShape) -> rds::FixedUtil {
+        match shape {
+            rds::WorkerShape::CpuOnly(s) => s.num_cpus,
+            rds::WorkerShape::FractionalGpu(s) => s.num_cpus,
+            rds::WorkerShape::WholeNumberedGpu(s) => {
+                s.num_cpus * rds::FixedUtil::from_num(s.num_gpus)
+            }
+            rds::WorkerShape::SpmdSmallerThanNode(s) => {
+                s.num_cpus_per_actor * rds::FixedUtil::from_num(s.num_gpu_actors_in_group)
+            }
+            rds::WorkerShape::SpmdNodeMultiple(s) => s.num_cpus_needed_per_node(),
+        }
+    }
+
+    fn manual_gpu_can_be_used(used_fraction: rds::FixedUtil, shape: &rds::WorkerShape) -> bool {
+        match shape {
+            rds::WorkerShape::CpuOnly(_) => false,
+            rds::WorkerShape::FractionalGpu(s) => {
+                used_fraction + s.gpu_fraction <= rds::FixedUtil::ONE
+            }
+            rds::WorkerShape::WholeNumberedGpu(_)
+            | rds::WorkerShape::SpmdNodeMultiple(_)
+            | rds::WorkerShape::SpmdSmallerThanNode(_) => used_fraction == rds::FixedUtil::ZERO,
+        }
+    }
+
+    fn manual_can_allocate(node: &rds::NodeResources, shape: &rds::WorkerShape) -> bool {
+        if node.used_cpus + manual_cpus_needed_for_shape(shape) > node.total_cpus {
+            return false;
+        }
+        match shape {
+            rds::WorkerShape::CpuOnly(_) => true,
+            rds::WorkerShape::FractionalGpu(_) => node
+                .gpus
+                .iter()
+                .any(|gpu| manual_gpu_can_be_used(gpu.used_fraction, shape)),
+            rds::WorkerShape::WholeNumberedGpu(s) => {
+                node.num_fully_unallocated_gpus() >= s.num_gpus as usize
+            }
+            rds::WorkerShape::SpmdSmallerThanNode(s) => {
+                node.num_fully_unallocated_gpus() >= s.num_gpu_actors_in_group as usize
+            }
+            rds::WorkerShape::SpmdNodeMultiple(s) => {
+                node.gpus.len() == s.num_gpus_in_node as usize
+                    && node
+                        .gpus
+                        .iter()
+                        .all(|gpu| gpu.used_fraction == rds::FixedUtil::ZERO)
+            }
+        }
+    }
+
+    fn manual_unallocatable_gpus_for_shape(
+        node: &rds::NodeResources,
+        shape: &rds::WorkerShape,
+    ) -> f32 {
+        let total_available_gpus: f32 = node
+            .gpus
+            .iter()
+            .map(|gpu| 1.0 - gpu.used_fraction.to_num::<f32>())
+            .sum();
+
+        if matches!(shape, rds::WorkerShape::CpuOnly(_)) {
+            return total_available_gpus;
+        }
+        if !manual_can_allocate(node, shape) {
+            return total_available_gpus;
+        }
+
+        node.gpus
+            .iter()
+            .filter(|gpu| !manual_gpu_can_be_used(gpu.used_fraction, shape))
+            .map(|gpu| 1.0 - gpu.used_fraction.to_num::<f32>())
+            .sum()
+    }
+
+    fn manual_estimate_fragmentation_on_node(
+        node: &rds::NodeResources,
+        workload: &Workload,
+    ) -> f32 {
+        workload
+            .stages
+            .iter()
+            .map(|stage| stage.frequency * manual_unallocatable_gpus_for_shape(node, &stage.shape))
+            .sum()
+    }
+
+    fn canonicalize_zero(value: f32) -> f32 {
+        if value == 0.0 {
+            0.0
+        } else {
+            value
+        }
+    }
+
     // --------------------
     // Fragmentation Calculation Tests
     // --------------------
@@ -2730,5 +2825,247 @@ mod tests {
 
         // Should allocate to one of the available nodes
         assert_eq!(allocation.node, "1");
+    }
+
+    // --------------------
+    // ScratchView correctness tests
+    // --------------------
+    //
+    // These tests guard the refactor that replaced the legacy "mutate the cluster, score,
+    // restore" simulation with the side-effect-free [`ScratchView`] overlay used by FGD.
+    // The contract we care about is: for any (node, candidate allocation, workload),
+    // overlay-based scoring must produce the *same* fragmentation value as physically
+    // applying the allocation to a clone of the node and scoring it. If this ever
+    // diverges, FGD's per-candidate ranking would silently drift.
+
+    /// Builds a randomized workload with 1..=4 stages, normalized frequencies, and a mix
+    /// of CPU-only / fractional / whole-GPU shapes so the property test exercises all
+    /// branches of `unallocatable_gpus_for_shape`.
+    fn random_workload(rng: &mut impl rand::Rng) -> Workload {
+        let num_stages = rng.random_range(1usize..=4);
+
+        let candidate_shapes = [
+            rds::WorkerShape::CpuOnly(rds::CpuOnly {
+                num_cpus: rds::FixedUtil::ONE,
+            }),
+            rds::WorkerShape::CpuOnly(rds::CpuOnly {
+                num_cpus: rds::FixedUtil::from_num(2.0),
+            }),
+            rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+                gpu_fraction: rds::FixedUtil::from_num(0.1),
+                num_cpus: rds::FixedUtil::ONE,
+            }),
+            rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+                gpu_fraction: rds::FixedUtil::from_num(0.25),
+                num_cpus: rds::FixedUtil::ONE,
+            }),
+            rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+                gpu_fraction: rds::FixedUtil::from_num(0.5),
+                num_cpus: rds::FixedUtil::from_num(2.0),
+            }),
+            rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+                gpu_fraction: rds::FixedUtil::from_num(0.75),
+                num_cpus: rds::FixedUtil::from_num(2.0),
+            }),
+            rds::WorkerShape::WholeNumberedGpu(rds::WholeNumberedGpu {
+                num_gpus: 1,
+                num_cpus: rds::FixedUtil::from_num(2.0),
+            }),
+            rds::WorkerShape::WholeNumberedGpu(rds::WholeNumberedGpu {
+                num_gpus: 2,
+                num_cpus: rds::FixedUtil::from_num(2.0),
+            }),
+            rds::WorkerShape::SpmdSmallerThanNode(rds::SpmdSmallerThanNodeResources {
+                num_gpu_actors_in_group: 1,
+                num_cpus_per_actor: rds::FixedUtil::ONE,
+                num_gpus_in_node: 2,
+            }),
+            rds::WorkerShape::SpmdSmallerThanNode(rds::SpmdSmallerThanNodeResources {
+                num_gpu_actors_in_group: 2,
+                num_cpus_per_actor: rds::FixedUtil::from_num(1.5),
+                num_gpus_in_node: 4,
+            }),
+        ];
+
+        // Raw weights → normalized frequencies summing to 1.0 (matching the production
+        // `make_workload_from_state` output format). Clamp to >= 1 so we never divide by 0.
+        let weights: Vec<f32> = (0..num_stages)
+            .map(|_| rng.random_range(1u32..=10) as f32)
+            .collect();
+        let total: f32 = weights.iter().sum();
+
+        let stages = weights
+            .iter()
+            .map(|w| Stage {
+                frequency: w / total,
+                shape: candidate_shapes[rng.random_range(0..candidate_shapes.len())].clone(),
+            })
+            .collect();
+        Workload { stages }
+    }
+
+    /// Cross-checks [`ScratchView::score_after_allocate`] / [`score_after_release`] against
+    /// the hand-rolled reference implementations (`manual_estimate_fragmentation_on_node` &
+    /// friends) defined above, across many randomized nodes, shapes, initial usages, GPU
+    /// counts, and workload compositions. The reference impl is intentionally independent
+    /// of `ScratchView::estimate_fragmentation`, so a bug introduced in *either* the overlay
+    /// plumbing or the production scoring function will trip this test.
+    ///
+    /// Each trial scores the real candidate *after* first polluting the `ScratchView` with
+    /// an unrelated allocation. This forces `reset()` to actually do work — the way it is
+    /// used in production (FGD reuses a single `ScratchView` across every candidate on a
+    /// node) — rather than being a no-op on a fresh overlay.
+    ///
+    /// Bit-exact equality via [`f32::to_bits`] is the contract here; if `estimate_fragmentation`
+    /// ever changes its reduction order, this assertion will need to be relaxed to an
+    /// approximate comparison. That's intentional: a bit-level regression is noise-proof.
+    #[test]
+    fn test_scratch_view_overlay_matches_manual_reference() {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        // Fixed seed so CI failures are genuine regressions, not sampling variance.
+        const OVERLAY_PROPERTY_TEST_SEED: u64 = 0x00C0_FFEE_F0F0;
+        let mut rng = StdRng::seed_from_u64(OVERLAY_PROPERTY_TEST_SEED);
+
+        let candidate_shapes = [
+            rds::WorkerShape::CpuOnly(rds::CpuOnly {
+                num_cpus: rds::FixedUtil::ONE,
+            }),
+            rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+                gpu_fraction: rds::FixedUtil::from_num(0.25),
+                num_cpus: rds::FixedUtil::ONE,
+            }),
+            rds::WorkerShape::FractionalGpu(rds::FractionalGpu {
+                gpu_fraction: rds::FixedUtil::from_num(0.5),
+                num_cpus: rds::FixedUtil::from_num(2.0),
+            }),
+            rds::WorkerShape::WholeNumberedGpu(rds::WholeNumberedGpu {
+                num_gpus: 1,
+                num_cpus: rds::FixedUtil::from_num(2.0),
+            }),
+            rds::WorkerShape::SpmdSmallerThanNode(rds::SpmdSmallerThanNodeResources {
+                num_gpu_actors_in_group: 2,
+                num_cpus_per_actor: rds::FixedUtil::from_num(1.5),
+                num_gpus_in_node: 4,
+            }),
+        ];
+
+        // Iterate enough trials to cover the cartesian product of shape × usage patterns
+        // × workload compositions we care about; 500 keeps the test fast (<200ms) while
+        // still randomizing widely.
+        let mut trials_run = 0;
+        for trial in 0..500 {
+            let num_gpus = rng.random_range(1usize..=8);
+            let total_cpus_int = rng.random_range(8u8..=64);
+            let total_cpus = total_cpus_int as f32;
+
+            // Mix of free, partially-used, and (occasionally) nearly-full GPUs so we
+            // exercise both the fractional and whole-GPU branches of `unallocatable_gpus_for_shape`.
+            let gpus: Vec<rds::GpuResources> = (0..num_gpus)
+                .map(|i| {
+                    let bucket = rng.random_range(0u8..6);
+                    let used = match bucket {
+                        0 | 1 => 0.0, // ~33% fully free
+                        2 => 0.25,
+                        3 => 0.5,
+                        4 => 0.75,
+                        _ => 0.95,
+                    };
+                    gpu_with_usage(i as u8, used)
+                })
+                .collect();
+
+            let used_cpus = rng.random_range(0u8..=(total_cpus_int / 2)) as f32;
+            let node = node_with_usage("rand", used_cpus, total_cpus, gpus);
+
+            // Workload is randomized per trial so the test actually exercises the
+            // weighting and shape-mix logic in `estimate_fragmentation`.
+            let workload = random_workload(&mut rng);
+            let shape = &candidate_shapes[rng.random_range(0..candidate_shapes.len())];
+
+            // Use the production candidate generator so we score *real* allocations.
+            let allocs = find_possible_allocations_on_node(&node, shape, "rand");
+            if allocs.is_empty() {
+                continue;
+            }
+            let alloc = &allocs[rng.random_range(0..allocs.len())];
+
+            // ---- allocate path: manual reference (clone + mutate + score) vs overlay ----
+            let mut legacy_node = node.clone();
+            legacy_node
+                .allocate(alloc)
+                .expect("legacy allocate should succeed for a valid candidate");
+            let legacy_after = canonicalize_zero(manual_estimate_fragmentation_on_node(
+                &legacy_node,
+                &workload,
+            ));
+
+            // Pollute the overlay with an unrelated scratch allocation first, so
+            // `score_after_allocate` must call `reset()` to recover clean state. In
+            // production, FGD reuses one `ScratchView` across every candidate on a node;
+            // scoring on a fresh view would leave that hot path untested.
+            let mut sv = ScratchView::from_node(&node);
+            if let Some(pollutant) = allocs.iter().find(|a| a != &alloc) {
+                let _ = sv.score_after_allocate(pollutant, &workload);
+            } else {
+                let _ = sv.score_after_allocate(alloc, &workload);
+            }
+            let overlay_after = canonicalize_zero(sv.score_after_allocate(alloc, &workload));
+
+            assert_eq!(
+                legacy_after.to_bits(),
+                overlay_after.to_bits(),
+                "overlay/legacy divergence on allocate (trial {trial}): \
+                 num_gpus={num_gpus} alloc.cpus={} alloc.gpus={:?} \
+                 workload.stages={} legacy={legacy_after} overlay={overlay_after}",
+                alloc.cpus,
+                alloc.gpus,
+                workload.stages.len(),
+            );
+
+            // ---- release path: start from a node that already has `alloc` applied,
+            // then verify that releasing it via overlay matches releasing it physically.
+            let node_with_alloc = legacy_node;
+            let mut legacy_after_release = node_with_alloc.clone();
+            legacy_after_release.release_allocation(alloc);
+            let legacy_release = canonicalize_zero(manual_estimate_fragmentation_on_node(
+                &legacy_after_release,
+                &workload,
+            ));
+
+            // Same pollution trick for the release path — `score_after_release` must
+            // also call `reset()`, and fresh views would leave that uncovered.
+            let mut sv_release = ScratchView::from_node(&node_with_alloc);
+            if let Some(other_alloc_on_full_node) =
+                find_possible_allocations_on_node(&node_with_alloc, shape, "rand")
+                    .into_iter()
+                    .next()
+            {
+                let _ = sv_release.score_after_allocate(&other_alloc_on_full_node, &workload);
+            }
+            let overlay_release =
+                canonicalize_zero(sv_release.score_after_release(alloc, &workload));
+
+            assert_eq!(
+                legacy_release.to_bits(),
+                overlay_release.to_bits(),
+                "overlay/legacy divergence on release (trial {trial}): \
+                 num_gpus={num_gpus} alloc.cpus={} alloc.gpus={:?} \
+                 workload.stages={} legacy={legacy_release} overlay={overlay_release}",
+                alloc.cpus,
+                alloc.gpus,
+                workload.stages.len(),
+            );
+
+            trials_run += 1;
+        }
+
+        // Sanity: ensure the trial loop was not pathologically pruned by the
+        // empty-allocations early-continue (would silently weaken the guarantee).
+        assert!(
+            trials_run >= 100,
+            "expected at least 100 randomized trials to actually run, got {trials_run}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Refactors the Fragmentation Gradient Descent (FGD) inner loops in `fragmentation_allocation_algorithms.rs` to eliminate hot-path allocations and redundant work.

Delivers a **~13% wall-clock speedup** on a Mac laptop and **~26.4% wall-clock speedup** on a GB200 node with the large autoscaling benchmark (1000 nodes / 8000 GPUs / 240k CPUs). No behavioral changes and no Python API impact.

## What changed

- **`ScratchView` overlay struct.** FGD previously scored each candidate by mutating `ClusterResources` (`allocate` → score → `release`). This forced a `&mut` borrow and a heap round-trip per candidate. `ScratchView` captures the *effective* per-node state (CPU + per-GPU usage) in a reusable scratch buffer and provides pure `score_after_allocate` / `score_after_release` methods, so scoring runs on `&ClusterResources` and reuses a single buffer across all candidates on the same node.
- **Group-by-node in the delete path.** `find_worker_to_delete_using_fragmentation_gradient_descent` previously recomputed `frag_before` for every candidate worker. Candidates are now grouped by host node so `frag_before` is computed once per node and amortized across all its workers — a meaningful win when a stage concentrates workers on a few nodes.
- **Streaming reduction.** Both FGD functions now keep a single best `Candidate` (frag delta + tiebreaker + id/allocation) instead of pushing into a `Vec<FragmentationResult>` and sorting. Saves a per-call alloc + sort.
- **Drop `Worker` clone on the reuse path.** `AllocationResult.reused_worker: Option<Worker>` → `reused_worker_id: Option<String>`. The caller in `autoscaling_algorithms.rs` now `remove`s the worker from its map instead of cloning it.
- **Tighter caller borrows in `autoscaling_algorithms.rs`.** For deletions, the immutable borrow of `worker_map` is scoped tightly so the `remove` consumes the `Worker` directly into the result map (zero clones on the delete path too).

## Benchmark

Large autoscaling benchmark (`cargo run --release --bin benchmark_large_autoscaling_problem`):

### macOS (12-core Apple Silicon)
| Build | Real | User | CPU |
|---|---|---|---|
| Baseline (main) | 78.92s | 77.77s | 99% |
| This PR | 68.37s | 67.35s | 99% |
**~13.4% faster.**

### GB200 (Grace ARM)
| Build | Real | User | CPU |
|---|---|---|---|
| Baseline (main) | 119.36s | 118.99s | 99% |
| This PR | 87.91s | 87.88s | 99% |
**~26.4% faster**

The larger gain reflects greater sensitivity to allocator pressure and cache locality on ARM. Both platforms produce byte-identical `Speeds: [...]` output between baseline and this PR.

## API impact

None. All changes live below the PyO3 boundary:
- `AllocationResult`, `ScratchView`, and both FGD functions are plain Rust (`pub struct` / `pub fn`) — no `#[pyclass]` / `#[pyfunction]`.
- Python entry points (`run_fragmentation_autoscaler`, `FragmentationBasedAutoscaler`) keep identical signatures and return the same `Solution` shape.
- No `cosmos_xenna/**` Python changes required.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release` — 170 lib tests + 8 doctests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Benchmark comparison (baseline vs this PR) via `cargo run --release --bin benchmark_large_autoscaling_problem`, confirmed identical `Speeds: [...]` output
- [x] smoke-test against a single GB200 node
- [ ] smoke-test against a live cluster workload