### PR TITLE
fix: add Stage.destroy() lifecycle hook for clean worker teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Latest
 
+## [0.4.1]
+
+### Released
+
+- 2026-05-12
+
+### Fixed
+
+- Added Stage.destroy() lifecycle hook so workers can release resources before ray.kill()
+
 ## [0.4.0]
 
 ### Released

--- a/cosmos_xenna/pipelines/private/continuous_wrapped_stage.py
+++ b/cosmos_xenna/pipelines/private/continuous_wrapped_stage.py
@@ -108,6 +108,10 @@ class ContinuousWrappedStage(stage.Interface, ContinuousInterface):
         )
         raise NotImplementedError(msg)
 
+    def destroy(self) -> None:
+        """Forward the pre-shutdown teardown hook to the wrapped stage."""
+        self._stage.destroy()
+
     async def run_continuous(
         self,
         input_queue: asyncio.Queue[ContinuousTaskInput],

--- a/cosmos_xenna/pipelines/private/specs.py
+++ b/cosmos_xenna/pipelines/private/specs.py
@@ -266,6 +266,22 @@ class Stage(abc.ABC, Generic[T, V]):
         """
         pass
 
+    def destroy(self) -> None:
+        """Release per-worker resources before the actor exits.
+
+        Called by ``StageWorker.shutdown`` while the worker still has its conda env, GPU
+        attachments, and Python interpreter intact - before ``ray.kill()`` SIGKILLs the
+        actor. Stages that own external resources (vLLM EngineCore subprocesses, torch
+        CUDA contexts, native handles) should override this to free them synchronously
+        so that ``ray.kill()`` never has to terminate them out from under the driver,
+        which would leak GPU memory as ghost CUDA contexts.
+
+        Default is a no-op for stages with no such ownership. Implementations should be
+        bounded in time and tolerate being called even when ``setup`` did not complete.
+        Exceptions are caught by the caller and logged; they will not block teardown.
+        """
+        pass
+
     @abc.abstractmethod
     def process_data(self, in_data: list[T]) -> list[V] | None:
         """Processes the input data.
@@ -544,6 +560,9 @@ class WrappedStage(stage.Interface):
 
     def process_data(self, data: Any) -> Any:
         return self._stage.process_data(data)
+
+    def destroy(self) -> None:
+        self._stage.destroy()
 
 
 @attrs.define

--- a/cosmos_xenna/ray_utils/actor_pool.py
+++ b/cosmos_xenna/ray_utils/actor_pool.py
@@ -102,6 +102,11 @@ _REAP_GRACE_PERIOD_S = 15
 
 _GRACEFUL_SHUTDOWN_GRACE_PERIOD_S = 30.0
 _GRACEFUL_SHUTDOWN_RPC_BUFFER_S = 5.0
+# Worker-side budget for the user stage's destroy() during shutdown. Must be at least
+# ``stage_worker._USER_STAGE_DESTROY_TIMEOUT_S`` so the RPC does not time out before
+# destroy() finishes. Duplicated here (rather than imported) to avoid creating a
+# stage_worker -> actor_pool import cycle.
+_USER_STAGE_DESTROY_BUDGET_S = 10.0
 
 
 @ray.remote(num_cpus=0)
@@ -152,37 +157,41 @@ def _reap_pids(pid_entries: list[tuple[int, float | None]]) -> None:
 
 
 def _attempt_graceful_shutdown(actor_ref: ActorHandle, label: str, grace_period_s: float) -> bool:
-    """Ask the worker to drain in-flight work before we ``ray.kill()`` it.
+    """Ask the worker to drain in-flight work and release per-worker resources.
 
-    This is a *cooperative* pre-step: ``StageWorker.shutdown`` sets the stop
-    flag, joins its internal threads up to ``grace_period_s``, and returns
-    a bool indicating whether the join completed. We always proceed to
-    ``ray.kill()`` regardless of the outcome - a graceful drain just lets
-    the actor publish results from in-flight tasks first (continuous mode)
-    or finish a batch (batch mode); the kill is what releases Ray
-    resources.
+    Two-phase cooperative pre-step before ``ray.kill()``:
 
-    The ``ray.get`` timeout adds ``_GRACEFUL_SHUTDOWN_RPC_BUFFER_S`` over
-    ``grace_period_s`` so that the worker's own join can finish and return
-    its bool to the caller before we abandon the wait. If the worker never
-    returns (e.g. it is wedged in C extension code), we still bound the
-    total cost at ``grace_period_s + buffer`` and continue to the kill.
+      * ``StageWorker.shutdown`` always invokes the user stage's ``destroy()`` with a
+        fixed budget (``_USER_STAGE_DESTROY_BUDGET_S``) so per-worker GPU/native
+        resources are released even when no drain is requested. Skipping this is what
+        leaks vLLM EngineCore subprocesses as ghost CUDA contexts after ``ray.kill()``.
+      * If ``grace_period_s > 0``, the worker also joins its internal threads up to
+        ``grace_period_s``. With ``grace_period_s == 0`` (autoscaler downsizes and
+        pipeline-end ``stop()`` - paths where drained results would be discarded
+        anyway), the thread join is skipped but destroy still runs.
 
-    Returns ``True`` if the worker reported a clean drain, ``False`` if it
-    reported timeout or if the RPC itself timed out / raised. The caller
-    uses this only for logging; the kill happens unconditionally.
+    The ``ray.get`` timeout covers both phases plus an RPC buffer. We always proceed
+    to ``ray.kill()`` regardless of the outcome - a graceful drain just lets the actor
+    publish in-flight results first; the kill is what releases Ray resources.
+
+    Returns ``True`` if the worker reported a clean drain, ``False`` if drain was
+    skipped or timed out, or if the RPC itself raised. The caller uses this only for
+    logging; the kill happens unconditionally.
     """
-    if grace_period_s <= 0.0:
-        return False
+    drain_s = max(0.0, grace_period_s)
+    rpc_timeout = drain_s + _USER_STAGE_DESTROY_BUDGET_S + _GRACEFUL_SHUTDOWN_RPC_BUFFER_S
     try:
         return bool(
             ray.get(
-                actor_ref.shutdown.remote(grace_period_s),  # type: ignore[attr-defined]
-                timeout=grace_period_s + _GRACEFUL_SHUTDOWN_RPC_BUFFER_S,
+                actor_ref.shutdown.remote(drain_s),  # type: ignore[attr-defined]
+                timeout=rpc_timeout,
             )
         )
     except ray.exceptions.GetTimeoutError:
-        logger.warning(f"graceful shutdown of {label} timed out after {grace_period_s:.1f}s; will hard-kill")
+        logger.warning(
+            f"graceful shutdown of {label} timed out after {rpc_timeout:.1f}s "
+            f"(drain={drain_s:.1f}s, destroy_budget={_USER_STAGE_DESTROY_BUDGET_S:.1f}s); will hard-kill"
+        )
         return False
     except Exception as e:  # noqa: BLE001 - best-effort, the kill is what guarantees cleanup
         logger.warning(f"graceful shutdown of {label} raised {type(e).__name__}: {e}; will hard-kill")
@@ -199,19 +208,19 @@ def _kill_actor_and_reap(
 
     Tear-down sequence::
 
-        1. _attempt_graceful_shutdown()   - cooperative drain (bounded)
+        1. _attempt_graceful_shutdown()   - destroy() + cooperative drain (bounded)
         2. _get_actor_pid_tree()           - snapshot for the reaper
         3. ray.kill(actor_ref)             - release Ray resources
         4. _reap_pids.remote()             - handle ray.kill() survivors
 
-    The graceful step is cheap when it succeeds (continuous-mode stages
-    drain in well under the grace period; batch-mode stages return
-    immediately because their threads were already idle between tasks).
-    When it fails, we bound the cost and proceed to the hard kill. The
-    PID-tree snapshot taken AFTER the graceful step is intentional: a
-    well-behaved stage may have already cleaned up its child processes
-    by then, leaving the snapshot small (or empty) and saving the
-    reaper from chasing PIDs that no longer exist.
+    The graceful step always runs the user stage's ``destroy()`` (bounded by
+    ``_USER_STAGE_DESTROY_BUDGET_S``) so GPU/native resources are released even
+    when ``grace_period_s == 0`` and no drain is requested. When
+    ``grace_period_s > 0`` an additional cooperative drain runs after destroy.
+    The PID-tree snapshot taken AFTER the graceful step is intentional: a
+    well-behaved stage (or one with a working ``destroy()``) will have already
+    cleaned up its child processes by then, leaving the snapshot small (or
+    empty) and saving the reaper from chasing PIDs that no longer exist.
     """
     drained = _attempt_graceful_shutdown(actor_ref, label, grace_period_s)
     pid_entries = _get_actor_pid_tree(actor_ref)

--- a/cosmos_xenna/ray_utils/stage.py
+++ b/cosmos_xenna/ray_utils/stage.py
@@ -98,3 +98,19 @@ class Interface(abc.ABC):
     @abc.abstractmethod
     def process_data(self, data: list[Any]) -> list[Any]:
         pass
+
+    def destroy(self) -> None:
+        """Release per-worker resources before the actor process exits.
+
+        Invoked by ``StageWorker.shutdown`` while the worker still has its conda env, GPU
+        attachments, and Python interpreter intact - i.e. before ``ray.kill()`` SIGKILLs
+        the actor. Stages that own external resources (vLLM EngineCore subprocesses,
+        torch CUDA contexts, native handles) should override this to free them
+        synchronously so that ``ray.kill()`` never has to terminate them out from under
+        the driver, which would leak GPU memory as ghost CUDA contexts.
+
+        Default is a no-op for stages with no such ownership. Implementations should be
+        bounded in time and tolerate being called even when ``setup`` did not complete.
+        Exceptions are caught by the caller and logged; they will not block teardown.
+        """
+        return

--- a/cosmos_xenna/ray_utils/stage_worker.py
+++ b/cosmos_xenna/ray_utils/stage_worker.py
@@ -121,6 +121,11 @@ __all__ = [
 # ``_collect_continuous_async``).
 _CONTINUOUS_POLL_INTERVAL_S = 0.1
 
+# Maximum time the user stage's ``destroy()`` is given to release per-worker resources
+# during graceful shutdown. Capped so a misbehaving destroy cannot stall the actor pool's
+# teardown sequence; the rest of the shutdown grace period is reserved for thread joins.
+_USER_STAGE_DESTROY_TIMEOUT_S = 10.0
+
 
 @attrs.define
 class _Result(Generic[V]):
@@ -978,16 +983,77 @@ class StageWorker(abc.ABC, Generic[T, V]):
         except psutil.NoSuchProcess:
             return [(os.getpid(), 0.0)]
 
+    def _call_user_stage_destroy(self, timeout_s: float) -> None:
+        """Invoke the user stage's ``destroy()`` with a bounded timeout.
+
+        Runs the call in a worker thread so that a misbehaving implementation (hung
+        native call, infinite loop) cannot stall the actor pool. Exceptions are logged
+        but never re-raised: teardown must always proceed to ``ray.kill()`` to release
+        Ray resources, even when the user destroy fails.
+        """
+        if timeout_s <= 0.0:
+            return
+
+        def _run() -> None:
+            try:
+                self._stage_interface.destroy()
+            except Exception:  # noqa: BLE001 - destroy is best-effort; we log and proceed
+                logger.exception("Error in user stage destroy() during shutdown")
+
+        t = threading.Thread(target=_run, name="user_stage_destroy", daemon=True)
+        t.start()
+        t.join(timeout=timeout_s)
+        if t.is_alive():
+            logger.warning(
+                f"StageWorker.shutdown: user stage destroy() did not complete within {timeout_s:.1f}s; "
+                "proceeding to thread joins. Hung destroy may leak GPU/native resources after ray.kill()."
+            )
+
     def shutdown(self, grace_period_s: float = 30.0) -> bool:
-        """Signal stop and wait up to ``grace_period_s`` for thread exit."""
+        """Signal stop, run the user stage's destroy(), and wait for thread exit.
+
+        Two-phase teardown:
+
+          1. Set the stop flag and call ``destroy()`` on the user stage with a fixed
+             ``_USER_STAGE_DESTROY_TIMEOUT_S`` budget that is independent of
+             ``grace_period_s``. This is the only point at which the user gets a
+             chance to release GPU/native handles while the actor still has a live
+             Python interpreter and the right conda env - the subsequent
+             ``ray.kill()`` SIGKILLs the actor and orphans any child processes (e.g.
+             vLLM EngineCore), which leaks GPU memory as ghost CUDA contexts.
+             ``destroy()`` runs even when ``grace_period_s == 0`` (autoscaler
+             downsizes, pipeline-end ``stop()``) because those paths still need GPU
+             resources released - only the *drain* of in-flight tasks is skipped.
+
+          2. If ``grace_period_s > 0``, join the worker threads. Calling ``destroy()``
+             first is intentional: tearing down e.g. a vLLM EngineCore unblocks any
+             in-flight RPC the processor thread is wedged in, letting the join
+             succeed instead of timing out and forcing a hard kill.
+
+        Returns ``True`` if all worker threads joined within budget, ``False`` if any
+        thread is still alive (caller should then ``ray.kill()`` to release Ray
+        resources). When ``grace_period_s == 0`` the return is always ``False``
+        (signal-only mode), but ``destroy()`` has still run.
+        """
         self.stop_flag.set()
+
+        # Phase 1: user-stage destroy. Always runs with the full destroy budget,
+        # independent of grace_period_s. The drain semantics (grace_period_s) only
+        # control whether we wait for in-flight tasks to complete; releasing per-worker
+        # GPU/native resources is orthogonal and must happen on every teardown path -
+        # including pipeline-end and autoscaler downsizes, which pass grace_period_s=0
+        # because they have no in-flight tasks to drain. Skipping destroy on the
+        # graceful=False path leaks vLLM EngineCore subprocesses as ghost CUDA contexts.
+        self._call_user_stage_destroy(_USER_STAGE_DESTROY_TIMEOUT_S)
+
         if grace_period_s <= 0.0:
             # Non-blocking signal-only mode - caller will follow with
-            # ``ray.kill()`` and does not care whether we drained cleanly.
+            # ``ray.kill()`` and does not care whether in-flight tasks drained.
             return False
 
-        # Split the budget: short caps for the I/O threads (they unblock on
-        # the next 100 ms poll), the remainder for the processor thread.
+        # Phase 2: thread joins on the remaining budget. Short caps for the I/O
+        # threads (they unblock on the next 100 ms poll), the remainder for the
+        # processor thread.
         io_cap = min(1.0, grace_period_s / 4.0)
         processor_cap = max(0.0, grace_period_s - 2 * io_cap)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmos-xenna"
-version = "0.4.0"
+version = "0.4.1"
 description = "A framework for building and running distributed, AI-powered data pipelines using Ray"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -258,7 +258,7 @@ wheels = [
 
 [[package]]
 name = "cosmos-xenna"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

Adds an optional `destroy()` hook that the worker calls on every teardown path —
including the autoscaler downsize and end-of-pipeline `stop()` paths that previously
bypassed `shutdown.remote()` entirely. Stages that own external resources (vLLM
EngineCore subprocesses, CUDA contexts, native handles, child ffmpeg processes)
finally have a place to release them *before* `ray.kill()` orphans them.

Without this, a vLLM stage's `EngineCore` subprocess was being SIGKILLed by Ray's
survivor reaper, leaving ~169 GiB of GPU memory stranded as "ghost CUDA contexts"
that persisted across actor lifecycles and broke subsequent setups.

## Changes

- New `destroy()` method on `Interface` / `Stage` / `WrappedStage` /
  `ContinuousWrappedStage` (no-op default, fully backward compatible).
- `StageWorker.shutdown()` always invokes `destroy()` with a bounded
  `_USER_STAGE_DESTROY_TIMEOUT_S` budget — independent of `grace_period_s`,
  because releasing per-worker resources is orthogonal to draining in-flight tasks.
- `_attempt_graceful_shutdown()` always issues the `shutdown.remote` RPC, even when
  the caller passes `grace_period_s == 0` (autoscaler downsize, pipeline-end stop).

## Impact

- Existing stages with no `destroy()` override: unchanged behavior (no-op).
- Downstream worker teardown gains up to ~10 s per actor when stages implement
  `destroy()`; acceptable cost in exchange for not leaking GPU/native resources.

## Follow-ups

- Cut `v0.4.1` and update consumers (cosmos-curator) to bump the pin.