### PR TITLE
fix: protect mid-setup and new-ready workers from autoscaler scale-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Latest
 
+## [0.4.2]
+
+### Released
+
+- 2026-05-18
+
+### Fixed
+
+- Protect mid-setup and freshly-ready workers from autoscaler scale-down
+  - Pending-actor protection: defer any proposed deletion whose worker group is not yet in READY state.
+  - Post-Ready grace: defer any deletion whose worker group transitioned to READY less than ``StreamingSpecificSpec.scale_down_grace_after_ready_s`` (default 60.0) ago. Set to 0.0 to disable.
+  - End-of-stage drain bypasses both filters via ``stages_is_dones`` so final teardown is never delayed.
+
 ## [0.4.1]
 
 ### Released

--- a/cosmos_xenna/pipelines/private/specs.py
+++ b/cosmos_xenna/pipelines/private/specs.py
@@ -405,6 +405,22 @@ class StreamingSpecificSpec:
     # starvation pattern where source completion triggers aggressive CPU-stage scale-down before
     # queued work has drained.
     enable_backlog_aware_scaledown: bool = False
+    # Grace period applied to *newly Ready* worker groups before the autoscaler is
+    # allowed to delete them. Worker groups still in setup are always protected
+    # (independent of this value); the grace extends that protection for a short
+    # window after they reach Ready.
+    #
+    # The motivation is preventing the "thrash" pattern where the Rust autoscaler
+    # spins up a worker, the worker finishes an expensive setup (e.g. vLLM model
+    # load + ``torch.compile`` for a large LLM, ~60-90 s), and the *very next*
+    # autoscaler tick decides the queue is momentarily empty and tears the worker
+    # down. The setup cost is then wasted and, for GPU stages, the SIGKILL-on-
+    # destroy fallback raises the risk of orphaned CUDA contexts.
+    #
+    # Set to ``0.0`` to disable the post-Ready grace (pending-actor protection
+    # still applies). End-of-stage teardown bypasses the grace via the
+    # ``stages_is_dones`` flag so final drain is never delayed.
+    scale_down_grace_after_ready_s: float = 60.0
 
 
 @attrs.define

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -391,6 +391,11 @@ class Autoscaler:
         self._autoscale_future: Optional[concurrent.futures.Future] = None
         self._autoscale_start_time: float = 0.0
         self._enable_backlog_guard: bool = mode_specific.enable_backlog_aware_scaledown
+        # Post-Ready grace period. See ``StreamingSpecificSpec`` for
+        # rationale. Pending-actor protection is independent of this
+        # value and always on; the grace only extends protection past
+        # the Pending -> Ready transition.
+        self._scale_down_grace_after_ready_s: float = mode_specific.scale_down_grace_after_ready_s
 
     def __enter__(self) -> Autoscaler:
         """Enters the context manager."""
@@ -606,9 +611,41 @@ class Autoscaler:
                 logger.debug(f"Adding actor to create: {w.to_worker_group(pool.name)}")
                 pool.add_actor_to_create(w.to_worker_group(pool.name))
 
+            # Defer scale-down of worker groups that either haven't
+            # finished setup *or* finished setup within the last
+            # ``scale_down_grace_after_ready_s`` seconds. The Rust
+            # autoscaler reasons in terms of integer worker counts and
+            # has no notion of "this actor is mid-setup" or "this
+            # actor just came online". Killing a freshly-provisioned
+            # actor would (a) waste the in-flight setup cost (vLLM
+            # model load + ``torch.compile`` is ~60-90 s for a 27B
+            # FP8 model) and (b) for GPU stages, escalate to SIGKILL
+            # of EngineCore mid-init -- a known source of ghost CUDA
+            # contexts that the destroy() hook cannot recover from.
+            # The autoscaler will reconsider the deletion next tick
+            # once setup completes and the grace expires.
+            #
+            # End-of-stage teardown bypasses this guard via the
+            # ``stages_is_dones`` flag so final drain can still kill
+            # in-flight setups.
+            deferred_setup = 0
             for w in deletions:
-                logger.debug(f"Adding actor to delete: {w.to_worker_group(pool.name)}")
-                pool.add_actor_to_delete(w.to_worker_group(pool.name))
+                wg = w.to_worker_group(pool.name)
+                if not stages_is_dones[idx] and not pool.is_worker_group_ready(
+                    wg.id, min_age_s=self._scale_down_grace_after_ready_s
+                ):
+                    deferred_setup += 1
+                    continue
+                logger.debug(f"Adding actor to delete: {wg}")
+                pool.add_actor_to_delete(wg)
+
+            if deferred_setup > 0:
+                logger.info(
+                    f"Deferred scale-down of {deferred_setup} worker group(s) for stage "
+                    f"{pool.name} that are still in setup or within the "
+                    f"{self._scale_down_grace_after_ready_s:.0f}s post-Ready grace; "
+                    f"will reconsider next tick."
+                )
 
         self._autoscale_future = None
         autoscale_end_time = time.time()

--- a/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
+++ b/cosmos_xenna/pipelines/private/test_autoscaler_queue_aware_guard.py
@@ -105,6 +105,7 @@ def _make_autoscaler_with_solution(solution: MagicMock, enable_backlog_guard: bo
     # (a literal ``0.0`` would yield ``time.time() - 0.0`` >> 1.0s).
     autoscaler._autoscale_start_time = time.time()
     autoscaler._enable_backlog_guard = enable_backlog_guard
+    autoscaler._scale_down_grace_after_ready_s = 0.0
     return autoscaler
 
 

--- a/cosmos_xenna/ray_utils/actor_pool.py
+++ b/cosmos_xenna/ray_utils/actor_pool.py
@@ -509,6 +509,12 @@ class _WorkerGroup:
     actors: set[str]
     state: _WorkerGroupState
     rendevous_params: resources.NcclRendevousParams | None
+    # Wall-clock time (``time.time()``) when the worker group most recently
+    # transitioned into ``_WorkerGroupState.READY``. ``None`` while still in
+    # setup. Consumed by ``ActorPool.is_worker_group_ready`` to implement the
+    # post-Ready scale-down grace period (see
+    # ``StreamingSpecificSpec.scale_down_grace_after_ready_s``).
+    ready_at: float | None = None
 
     @property
     def id_(self) -> str:
@@ -843,6 +849,39 @@ class ActorPool(Generic[T, V]):
 
     def add_actor_to_create(self, worker: resources.WorkerGroup) -> None:
         self._worker_groups_to_create.append(worker)
+
+    def is_worker_group_ready(self, worker_group_id: str, min_age_s: float = 0.0) -> bool:
+        """Return True iff the group is Ready *and* has been Ready for ``min_age_s``.
+
+        Used by the autoscaler-application path to defer scale-down of
+        worker groups that are still in setup or that just finished setup.
+        Killing a pending actor aborts an in-progress, expensive setup
+        (e.g. vLLM model load and ``torch.compile``) and risks leaking
+        GPU memory because ``EngineCore`` subprocesses get SIGKILLed
+        mid-init when their SIGTERM grace expires.
+
+        The ``min_age_s`` parameter extends that protection for a short
+        window after the group transitions to Ready, preventing the
+        "spin up, finish setup, get torn down next tick" thrash pattern.
+        A value of ``0.0`` requests no post-Ready grace; the predicate
+        then degenerates to "is the group Ready?".
+
+        Returns ``False`` for unknown worker group ids so callers can
+        treat "not ready" and "not present" identically -- both mean
+        "not safe to scale down right now".
+        """
+        wg = self._worker_groups.get(worker_group_id)
+        if wg is None or wg.state != _WorkerGroupState.READY:
+            return False
+        if min_age_s <= 0.0:
+            return True
+        # ``ready_at`` is set atomically with the state transition in
+        # ``_move_worker_group_to_ready_if_all_actors_ready``; guard against
+        # ``None`` defensively in case a future code path mutates state
+        # without updating the timestamp.
+        if wg.ready_at is None:
+            return True
+        return (time.time() - wg.ready_at) >= min_age_s
 
     def set_num_slots_per_actor(self, target: int) -> None:
         if target < self._slots_per_actor:
@@ -1182,6 +1221,7 @@ class ActorPool(Generic[T, V]):
         if all(actor_id in self._ready_actors for actor_id in worker_group.actors):
             logger.debug(f"Moving worker group {worker_group_id} to ready state.")
             worker_group.state = _WorkerGroupState.READY
+            worker_group.ready_at = time.time()
 
     def _move_pending_actors_to_ready(self) -> None:
         """Checks for completed setup calls and transitions actors from pending to ready."""

--- a/cosmos_xenna/ray_utils/test_actor_pool_is_worker_group_ready.py
+++ b/cosmos_xenna/ray_utils/test_actor_pool_is_worker_group_ready.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``ActorPool.is_worker_group_ready``.
+
+The predicate is consumed by ``Autoscaler.apply_autoscale_result_if_ready``
+to defer scale-down of worker groups whose actors are still in setup or
+have only just finished setup. The contract under test:
+
+  * Returns ``True`` only when the worker group exists, its state has
+    transitioned to ``READY`` (all actors finished setup), *and* the
+    optional ``min_age_s`` post-Ready grace has elapsed.
+  * Returns ``False`` for unknown ids, so callers can collapse "not
+    present" and "not ready" into a single "not safe to scale down" gate.
+"""
+
+import pytest
+
+from cosmos_xenna.ray_utils.actor_pool import (
+    ActorPool,
+    _WorkerGroup,
+    _WorkerGroupState,
+)
+
+
+def _make_pool_with_groups(groups: dict[str, _WorkerGroup]) -> ActorPool:
+    """Build a bare ``ActorPool`` exposing only the field under test."""
+    pool = object.__new__(ActorPool)
+    pool._worker_groups = groups
+    return pool
+
+
+def _make_group(state: _WorkerGroupState, ready_at: float | None = None) -> _WorkerGroup:
+    """Construct a minimal ``_WorkerGroup`` for state-only assertions.
+
+    ``worker_group``/``rendevous_params`` are not exercised by
+    ``is_worker_group_ready``; ``None`` keeps the fixture lightweight.
+    """
+    return _WorkerGroup(
+        worker_group=None,  # type: ignore[arg-type]
+        actors=set(),
+        state=state,
+        rendevous_params=None,
+        ready_at=ready_at,
+    )
+
+
+def test_returns_true_for_ready_group() -> None:
+    """A group that has reached READY is safe to scale down."""
+    pool = _make_pool_with_groups({"wg-ready": _make_group(_WorkerGroupState.READY)})
+    assert pool.is_worker_group_ready("wg-ready") is True
+
+
+def test_returns_false_for_waiting_for_setup_group() -> None:
+    """A group whose actors are still in setup must not be scaled down."""
+    pool = _make_pool_with_groups({"wg-pending": _make_group(_WorkerGroupState.WAITING_FOR_SETUP)})
+    assert pool.is_worker_group_ready("wg-pending") is False
+
+
+def test_returns_false_for_unknown_worker_group_id() -> None:
+    """Unknown ids are treated as not-ready so the deferral path stays safe."""
+    pool = _make_pool_with_groups({})
+    assert pool.is_worker_group_ready("does-not-exist") is False
+
+
+def test_distinguishes_groups_by_id() -> None:
+    """Lookup is per-id and does not aggregate across groups."""
+    pool = _make_pool_with_groups(
+        {
+            "wg-ready": _make_group(_WorkerGroupState.READY),
+            "wg-pending": _make_group(_WorkerGroupState.WAITING_FOR_SETUP),
+        }
+    )
+    assert pool.is_worker_group_ready("wg-ready") is True
+    assert pool.is_worker_group_ready("wg-pending") is False
+
+
+def test_grace_period_blocks_freshly_ready_group(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A group that became Ready less than ``min_age_s`` ago is still protected."""
+    fake_now = 1_000.0
+    monkeypatch.setattr("cosmos_xenna.ray_utils.actor_pool.time.time", lambda: fake_now)
+    pool = _make_pool_with_groups({"wg-fresh": _make_group(_WorkerGroupState.READY, ready_at=fake_now - 10.0)})
+    assert pool.is_worker_group_ready("wg-fresh", min_age_s=60.0) is False
+
+
+def test_grace_period_releases_after_elapsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Once ``min_age_s`` has elapsed the group is eligible for scale-down."""
+    fake_now = 1_000.0
+    monkeypatch.setattr("cosmos_xenna.ray_utils.actor_pool.time.time", lambda: fake_now)
+    pool = _make_pool_with_groups({"wg-mature": _make_group(_WorkerGroupState.READY, ready_at=fake_now - 75.0)})
+    assert pool.is_worker_group_ready("wg-mature", min_age_s=60.0) is True
+
+
+def test_grace_period_disabled_with_zero_min_age() -> None:
+    """``min_age_s=0`` short-circuits to the simple Ready check (no timestamp needed)."""
+    pool = _make_pool_with_groups({"wg-ready-no-ts": _make_group(_WorkerGroupState.READY, ready_at=None)})
+    assert pool.is_worker_group_ready("wg-ready-no-ts", min_age_s=0.0) is True
+
+
+def test_grace_period_skipped_when_ready_at_missing() -> None:
+    """Defensive fallthrough: missing ``ready_at`` does not strand a Ready group."""
+    pool = _make_pool_with_groups({"wg-no-ts": _make_group(_WorkerGroupState.READY, ready_at=None)})
+    # Even with a grace requested, an absent timestamp must not flip Ready -> not-ready;
+    # otherwise a code-path that forgot to stamp ``ready_at`` would silently strand
+    # a healthy worker indefinitely.
+    assert pool.is_worker_group_ready("wg-no-ts", min_age_s=60.0) is True
+
+
+def test_grace_period_does_not_promote_pending_groups(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A group still in setup remains not-ready regardless of how ``min_age_s`` is set."""
+    fake_now = 1_000.0
+    monkeypatch.setattr("cosmos_xenna.ray_utils.actor_pool.time.time", lambda: fake_now)
+    pool = _make_pool_with_groups({"wg-pending": _make_group(_WorkerGroupState.WAITING_FOR_SETUP, ready_at=None)})
+    assert pool.is_worker_group_ready("wg-pending", min_age_s=0.0) is False
+    assert pool.is_worker_group_ready("wg-pending", min_age_s=60.0) is False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmos-xenna"
-version = "0.4.1"
+version = "0.4.2"
 description = "A framework for building and running distributed, AI-powered data pipelines using Ray"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -258,7 +258,7 @@ wheels = [
 
 [[package]]
 name = "cosmos-xenna"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
The Rust autoscaler reasons in terms of integer worker counts and per-actor throughput. It has no notion of "this actor is mid-setup" or "this actor just came online", so during a brief queue lull it can propose deleting an actor whose setup() is still running, or one that finished setup seconds ago. For expensive GPU stages such as a vLLM captioner running a 27B FP8 model (60-90 s for model load + torch.compile) the cost shows up two ways:

  1. Wasted setup -- the in-flight load is thrown away and a fresh
     worker must repeat it on the next provisioning tick.
  2. Ghost CUDA contexts -- if destroy() escalates to SIGKILL of
     EngineCore mid-init, the residual context can't be reclaimed
     by the existing destroy() hook and squats on the GPU until
     reset.

Add two filters to ``Autoscaler.apply_autoscale_result_if_ready``:
  * Pending-actor protection: defer any proposed deletion whose
    worker group is not yet in READY state.
  * Post-Ready grace: defer any deletion whose worker group
    transitioned to READY less than
    ``StreamingSpecificSpec.scale_down_grace_after_ready_s``
    (default 60.0) ago. Set to 0.0 to disable.

End-of-stage drain bypasses both filters via ``stages_is_dones`` so final teardown is never delayed.

The Rust autoscaler will reconsider any deferred deletion on the next tick, so no scale-down decision is permanently lost -- only delayed past the danger window.