### PR TITLE
fix: extend stage destroy budgets so graceful teardown can complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Latest
 
+## [0.5.1]
+
+### Released
+
+- 2026-07-07
+
+### Fixed
+
+- Extended user stage `destroy()` and process reaper budgets so graceful worker teardown can finish for stages with slower internal shutdown, preventing premature SIGKILLs that can leave CUDA context memory behind.
+
 ## [0.5.0]
 
 ### Released

--- a/cosmos_xenna/ray_utils/actor_pool.py
+++ b/cosmos_xenna/ray_utils/actor_pool.py
@@ -159,7 +159,7 @@ def _get_actor_pid_tree(actor_ref: ActorHandle) -> list[tuple[int, float | None]
             return []
 
 
-_REAP_GRACE_PERIOD_S = 15
+_REAP_GRACE_PERIOD_S = 30
 
 _GRACEFUL_SHUTDOWN_GRACE_PERIOD_S = 30.0
 _GRACEFUL_SHUTDOWN_RPC_BUFFER_S = 5.0
@@ -167,7 +167,7 @@ _GRACEFUL_SHUTDOWN_RPC_BUFFER_S = 5.0
 # ``stage_worker._USER_STAGE_DESTROY_TIMEOUT_S`` so the RPC does not time out before
 # destroy() finishes. Duplicated here (rather than imported) to avoid creating a
 # stage_worker -> actor_pool import cycle.
-_USER_STAGE_DESTROY_BUDGET_S = 10.0
+_USER_STAGE_DESTROY_BUDGET_S = 45.0
 
 
 @ray.remote(num_cpus=0)

--- a/cosmos_xenna/ray_utils/stage_worker.py
+++ b/cosmos_xenna/ray_utils/stage_worker.py
@@ -124,7 +124,7 @@ _CONTINUOUS_POLL_INTERVAL_S = 0.1
 # Maximum time the user stage's ``destroy()`` is given to release per-worker resources
 # during graceful shutdown. Capped so a misbehaving destroy cannot stall the actor pool's
 # teardown sequence; the rest of the shutdown grace period is reserved for thread joins.
-_USER_STAGE_DESTROY_TIMEOUT_S = 10.0
+_USER_STAGE_DESTROY_TIMEOUT_S = 45.0
 
 
 @attrs.define

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmos-xenna"
-version = "0.5.0"
+version = "0.5.1"
 description = "A framework for building and running distributed, AI-powered data pipelines using Ray"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -258,7 +258,7 @@ wheels = [
 
 [[package]]
 name = "cosmos-xenna"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Bump _USER_STAGE_DESTROY_BUDGET_S (actor_pool) and _USER_STAGE_DESTROY_TIMEOUT_S (stage_worker) from 10 s to 45 s, and _REAP_GRACE_PERIOD_S from 15 s to 30 s.

vLLM caption workers in cosmos-curator run a two-phase internal shutdown (drain in-flight requests, then tear down EngineCore and the model-holding subprocess) that takes ~20 s end to end. The 10 s budget was expiring mid-shutdown and escalating to SIGKILL of the child that owns the CUDA primary context, leaking it as ghost memory on the GPU for tens of minutes and blocking downstream workers from admitting.

The two _USER_STAGE_DESTROY_* constants must move together (the RPC budget must be at least the worker-side timeout, as the existing docstring notes) and _REAP_GRACE_PERIOD_S is bumped proportionally so the reaper does not fire before ray.kill() propagates.