### PR TITLE
perf: batch actor teardown for parallel destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Latest
 
+## [0.5.3]
+
+### Changed
+
+- `ActorPool.stop()` tears actors down in parallel via a bounded thread pool, so shutdown wall time scales with the slowest actor's teardown rather than the sum across actors. The mid-pipeline autoscaler kill path is unchanged.
+
 ## [0.5.2]
 
 ### Released

--- a/cosmos_xenna/ray_utils/actor_pool.py
+++ b/cosmos_xenna/ray_utils/actor_pool.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import collections
+import concurrent.futures
 import copy
 import enum
 import os
@@ -296,6 +297,33 @@ def _kill_actor_and_reap(
                 node_id=node_id, soft=False
             ),
         ).remote(pid_entries)
+
+
+# Soft cap on concurrent teardown threads. Threads block on Ray RPCs, so this
+# bounds thread growth on large pools rather than acting as a throughput knob.
+_MAX_PARALLEL_ACTOR_KILLS = 64
+
+
+def _kill_actors_and_reap_parallel(
+    kills: list[tuple[ActorHandle, str, str, float]],
+    max_parallel: int = _MAX_PARALLEL_ACTOR_KILLS,
+) -> None:
+    """Kill each actor in ``kills`` in parallel via a bounded thread pool.
+
+    Each tuple ``(actor_ref, node_id, label, grace_period_s)`` is forwarded
+    verbatim to :func:`_kill_actor_and_reap`. Ray's driver API is thread-safe
+    and releases the GIL during blocking calls, so RPC waits inside each call
+    run concurrently and wall time is bounded by the slowest actor's teardown.
+    A no-op when ``kills`` is empty.
+    """
+    if not kills:
+        return
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(len(kills), max_parallel),
+        thread_name_prefix="actor-kill",
+    ) as ex:
+        # ``list(...)`` forces exception propagation from ``ex.map``.
+        list(ex.map(lambda args: _kill_actor_and_reap(*args), kills))
 
 
 _RATE_ESTIMATE_LOOKBACK_S = 60 * 10
@@ -1534,16 +1562,23 @@ class ActorPool(Generic[T, V]):
         for actor in self._ready_actors.values():
             actor.maybe_resize_num_slots_per_actor(self._slots_per_actor)
 
-    def _delete_worker_group(self, worker_group_id: str) -> resources.WorkerGroup:
-        """Deletes a worker group regardless of its current state."""
-        worker_group = self._worker_groups.pop(worker_group_id)
-        logger.debug(f"Deleting worker group {worker_group_id}.")
+    def _release_worker_group_resources(self, worker_group_id: str) -> _WorkerGroup:
+        """Release a worker group's allocator and port-registry entries.
 
-        # Remove the entire worker group from allocator (not individual actors)
+        Assumes the actors in the group are already dead or handed off to
+        another teardown path. Callers that still need to kill actors should
+        use :meth:`_delete_worker_group` instead.
+        """
+        worker_group = self._worker_groups.pop(worker_group_id)
         self._allocator.remove_worker(worker_group.worker_group.id)
         if self._is_spmd:
             self._cluster_port_registry.clear_port(worker_group.primary_node_id, worker_group_id)
+        return worker_group
 
+    def _delete_worker_group(self, worker_group_id: str) -> resources.WorkerGroup:
+        """Deletes a worker group regardless of its current state."""
+        logger.debug(f"Deleting worker group {worker_group_id}.")
+        worker_group = self._release_worker_group_resources(worker_group_id)
         for actor_id in worker_group.actors:
             self._delete_actor(actor_id)  # Use internal method that skips allocator removal
         return worker_group.worker_group
@@ -2170,25 +2205,61 @@ class ActorPool(Generic[T, V]):
         logger.trace(f"Finished update cycle for {self.name}")
 
     def stop(self) -> None:
-        """Terminates all actors managed by this pool and cleans up resources."""
+        """Terminate all actors managed by this pool and release its resources.
+
+        Actors are killed in parallel via :func:`_kill_actors_and_reap_parallel`,
+        so shutdown wall time is bounded by the slowest actor's teardown.
+        """
         logger.debug(f"Stopping actor pool {self.name}. Terminating all actors.")
-        actor_ids_to_kill = set()
 
-        # Collect IDs from all states
-        actor_ids_to_kill.update(self._pending_actors.keys())
-        actor_ids_to_kill.update(self._ready_actors.keys())
-        actor_ids_to_kill.update(pna.metadata.worker_id for pna in self._pending_node_actors.values())
+        # Ready actors use grace=0: drained results would be discarded at pipeline
+        # end but ``destroy()`` still runs to release GPU/native resources. Other
+        # states get a cooperative drain window.
+        kills: list[tuple[ActorHandle, str, str, float]] = []
+        kills.extend(
+            (
+                actor.actor_ref,
+                actor.metadata.allocation.node,
+                f"ready actor {actor.metadata.worker_id}",
+                0.0,
+            )
+            for actor in self._ready_actors.values()
+        )
+        kills.extend(
+            (
+                actor.actor_ref,
+                actor.metadata.allocation.node,
+                f"pending actor {actor.metadata.worker_id}",
+                _GRACEFUL_SHUTDOWN_GRACE_PERIOD_S,
+            )
+            for actor in self._pending_actors.values()
+        )
+        kills.extend(
+            (
+                actor.actor_ref,
+                actor.metadata.allocation.node,
+                f"node-setup actor {actor.metadata.worker_id}",
+                _GRACEFUL_SHUTDOWN_GRACE_PERIOD_S,
+            )
+            for actor in self._pending_node_actors.values()
+        )
         for waiting_list in self._actors_waiting_for_node_setup.values():
-            actor_ids_to_kill.update(wna.metadata.worker_id for wna in waiting_list)
+            kills.extend(
+                (
+                    actor.actor_ref,
+                    actor.metadata.allocation.node,
+                    f"waiting actor {actor.metadata.worker_id}",
+                    _GRACEFUL_SHUTDOWN_GRACE_PERIOD_S,
+                )
+                for actor in waiting_list
+            )
 
-        logger.debug(f"Found {len(actor_ids_to_kill)} actor IDs across all states to terminate.")
+        logger.debug(f"Parallel-killing {len(kills)} actor(s) across all states.")
+        _kill_actors_and_reap_parallel(kills)
 
-        # Kill worker groups
+        # Actors are already dead; only allocator / port-registry cleanup remains.
         for worker_group_id in list(self._worker_groups.keys()):
-            self._delete_worker_group(worker_group_id)
-
-        # TODO: Technically, we should clear up the worker groups here as well, but this is not a big deal as we do
-        # not expected users to re-use instances of ActorPool.
+            self._release_worker_group_resources(worker_group_id)
 
         # Surface any tasks the clear() below would otherwise drop
         # silently. Per-origin counts let the operator attribute the

--- a/cosmos_xenna/ray_utils/actor_pool.py
+++ b/cosmos_xenna/ray_utils/actor_pool.py
@@ -299,9 +299,10 @@ def _kill_actor_and_reap(
         ).remote(pid_entries)
 
 
-# Soft cap on concurrent teardown threads. Threads block on Ray RPCs, so this
-# bounds thread growth on large pools rather than acting as a throughput knob.
-_MAX_PARALLEL_ACTOR_KILLS = 64
+# Soft cap on concurrent teardown threads. Threads block on Ray RPCs and each
+# carries a stack (~8 MB), so this bounds memory during teardown of very large
+# pools.
+_MAX_PARALLEL_ACTOR_KILLS = 512
 
 
 def _kill_actors_and_reap_parallel(

--- a/cosmos_xenna/ray_utils/test_actor_pool_allocator_invariants.py
+++ b/cosmos_xenna/ray_utils/test_actor_pool_allocator_invariants.py
@@ -269,6 +269,7 @@ def _build_pool_with_one_worker_group(
             actor.kill()
 
     pool._delete_actor = _stub_delete_actor
+    pool._release_worker_group_resources = ap_module.ActorPool._release_worker_group_resources.__get__(pool)
     pool._delete_worker_group = ap_module.ActorPool._delete_worker_group.__get__(pool)
 
     return pool, actor, allocator

--- a/cosmos_xenna/ray_utils/test_kill_actors_parallel.py
+++ b/cosmos_xenna/ray_utils/test_kill_actors_parallel.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :func:`_kill_actors_and_reap_parallel`.
+
+Ray is not imported: the helper's orchestration is a thin
+``ThreadPoolExecutor`` fan-out and is unit-testable with mocks. The
+underlying ``_kill_actor_and_reap`` / ``_reap_pids`` behavior is covered
+by ``reap_pids_test.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+import cosmos_xenna.ray_utils.actor_pool as ap_module
+from cosmos_xenna.ray_utils.actor_pool import _kill_actors_and_reap_parallel
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_empty_kills_is_noop() -> None:
+    """No tuples -> no thread pool, no calls."""
+    with (
+        patch.object(ap_module, "_kill_actor_and_reap") as kill_mock,
+        patch.object(ap_module.concurrent.futures, "ThreadPoolExecutor") as pool_mock,
+    ):
+        _kill_actors_and_reap_parallel([])
+
+    kill_mock.assert_not_called()
+    pool_mock.assert_not_called()
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_forwards_each_tuple_verbatim() -> None:
+    """Each tuple is passed as positional args to ``_kill_actor_and_reap``."""
+    kills: list[tuple[object, str, str, float]] = [
+        (object(), "node-a", "ready actor 0", 0.0),
+        (object(), "node-b", "pending actor 1", 30.0),
+        (object(), "node-c", "waiting actor 2", 15.0),
+    ]
+
+    with patch.object(ap_module, "_kill_actor_and_reap") as kill_mock:
+        _kill_actors_and_reap_parallel(kills)  # type: ignore[arg-type]
+
+    assert kill_mock.call_count == len(kills)
+    # ThreadPoolExecutor.map preserves input order in results but not
+    # necessarily in call ordering; compare as a set of positional-arg tuples.
+    observed = {tuple(call.args) for call in kill_mock.call_args_list}
+    expected = {tuple(k) for k in kills}
+    assert observed == expected
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_kills_run_in_parallel() -> None:
+    """Wall time reflects concurrent execution."""
+    per_kill_s = 0.3
+    n = 4
+
+    def slow_kill(*_args: object, **_kwargs: object) -> None:
+        time.sleep(per_kill_s)
+
+    kills: list[tuple[object, str, str, float]] = [(object(), f"node-{i}", f"actor {i}", 0.0) for i in range(n)]
+
+    with patch.object(ap_module, "_kill_actor_and_reap", side_effect=slow_kill):
+        start = time.monotonic()
+        _kill_actors_and_reap_parallel(kills)  # type: ignore[arg-type]
+        elapsed = time.monotonic() - start
+
+    # Parallel wall time should be ~``per_kill_s`` regardless of ``n``; use a
+    # generous headroom to absorb CI scheduling noise.
+    assert elapsed < 0.6, f"expected parallel wall time < 0.6s but got {elapsed:.3f}s"
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_exception_in_one_worker_propagates() -> None:
+    """A worker exception surfaces to the caller (via ``list(ex.map(...))``)."""
+    kills: list[tuple[object, str, str, float]] = [
+        (object(), "node-0", "actor 0", 0.0),
+        (object(), "node-1", "actor 1", 0.0),
+        (object(), "node-2", "actor 2", 0.0),
+    ]
+    poisoned_label = kills[1][2]
+
+    def maybe_raise(_actor: object, _node: str, label: str, _grace: float) -> None:
+        if label == poisoned_label:
+            raise RuntimeError("boom")
+
+    with (
+        patch.object(ap_module, "_kill_actor_and_reap", side_effect=maybe_raise),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        _kill_actors_and_reap_parallel(kills)  # type: ignore[arg-type]
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_max_parallel_bounds_peak_concurrency() -> None:
+    """``max_parallel`` is a hard cap on concurrent worker invocations."""
+    max_parallel = 2
+    kills: list[tuple[object, str, str, float]] = [(object(), f"node-{i}", f"actor {i}", 0.0) for i in range(10)]
+
+    lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    def observe_concurrency(*_args: object, **_kwargs: object) -> None:
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+        # Hold the slot long enough for additional workers to overlap.
+        time.sleep(0.05)
+        with lock:
+            active -= 1
+
+    with patch.object(ap_module, "_kill_actor_and_reap", side_effect=observe_concurrency):
+        _kill_actors_and_reap_parallel(kills, max_parallel=max_parallel)  # type: ignore[arg-type]
+
+    assert peak <= max_parallel, f"peak concurrency {peak} exceeded cap {max_parallel}"
+    assert peak >= 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmos-xenna"
-version = "0.5.2"
+version = "0.5.3"
 description = "A framework for building and running distributed, AI-powered data pipelines using Ray"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "cosmos-xenna"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

`ActorPool.stop()` currently tears actors down serially, so pipeline shutdown wall time is `sum(destroy_i)`. This PR runs each actor's teardown concurrently via a bounded thread pool, dropping wall time to `max(destroy_i)`. The mid-pipeline autoscaler kill path is unchanged (it only kills one actor at a time).

This significantly reduces the teardown time of the actors at the end of a pipeline.

## Changes

- New _kill_actors_and_reap_parallel(kills) helper — fans the existing single-actor _kill_actor_and_reap out over a ThreadPoolExecutor. Each thread carries its own per-actor deadline exactly as in the serial path, so grace=0 actors still hard-kill at their own budget when scheduled alongside grace>0 actors. At most _MAX_PARALLEL_ACTOR_KILLS = 512 kills run concurrently; larger pools drain in overlapping waves as threads free up.
- `ActorPool.stop()` collects `(actor_ref, node_id, label, grace_period_s)` tuples across all four state buckets and hands them to the parallel helper.
- Test coverage
