### PR TITLE
fix: prevent mid-setup destroy() race during ActorPool.stop() teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Latest
 
+## [0.5.5]
+
+### Fixed
+
+- `ActorPool.stop()` skips the graceful drain and user `destroy()` for actors still in setup, avoiding a race with the in-flight `setup()` that surfaced as spurious `Engine core initialization failed` tracebacks. Those actors are torn down via `ray.kill()` plus the node-local pid reap.
+
 ## [0.5.4]
 
 ### Changed

--- a/cosmos_xenna/ray_utils/actor_pool.py
+++ b/cosmos_xenna/ray_utils/actor_pool.py
@@ -2213,9 +2213,10 @@ class ActorPool(Generic[T, V]):
         """
         logger.debug(f"Stopping actor pool {self.name}. Terminating all actors.")
 
-        # Ready actors use grace=0: drained results would be discarded at pipeline
-        # end but ``destroy()`` still runs to release GPU/native resources. Other
-        # states get a cooperative drain window.
+        # grace=0 for all states. Ready actors still run ``destroy()`` inside
+        # ``StageWorker.shutdown`` to release GPU/native resources. Pre-ready
+        # actors have no in-flight work to drain and ``StageWorker.shutdown``
+        # skips their ``destroy()``; cleanup falls to ``ray.kill()`` + reap.
         kills: list[tuple[ActorHandle, str, str, float]] = []
         kills.extend(
             (
@@ -2231,7 +2232,7 @@ class ActorPool(Generic[T, V]):
                 actor.actor_ref,
                 actor.metadata.allocation.node,
                 f"pending actor {actor.metadata.worker_id}",
-                _GRACEFUL_SHUTDOWN_GRACE_PERIOD_S,
+                0.0,
             )
             for actor in self._pending_actors.values()
         )
@@ -2240,7 +2241,7 @@ class ActorPool(Generic[T, V]):
                 actor.actor_ref,
                 actor.metadata.allocation.node,
                 f"node-setup actor {actor.metadata.worker_id}",
-                _GRACEFUL_SHUTDOWN_GRACE_PERIOD_S,
+                0.0,
             )
             for actor in self._pending_node_actors.values()
         )
@@ -2250,7 +2251,7 @@ class ActorPool(Generic[T, V]):
                     actor.actor_ref,
                     actor.metadata.allocation.node,
                     f"waiting actor {actor.metadata.worker_id}",
-                    _GRACEFUL_SHUTDOWN_GRACE_PERIOD_S,
+                    0.0,
                 )
                 for actor in waiting_list
             )

--- a/cosmos_xenna/ray_utils/stage_worker.py
+++ b/cosmos_xenna/ray_utils/stage_worker.py
@@ -990,7 +990,17 @@ class StageWorker(abc.ABC, Generic[T, V]):
         native call, infinite loop) cannot stall the actor pool. Exceptions are logged
         but never re-raised: teardown must always proceed to ``ray.kill()`` to release
         Ray resources, even when the user destroy fails.
+
+        Skipped when setup has not signalled completion: destroy() would race
+        resources setup is still acquiring (e.g. mid-spawn subprocesses).
+        ``ray.kill()`` + ``_reap_pids`` handle cleanup for that path.
         """
+        if not self._setup_completed.is_set():
+            logger.info(
+                f"StageWorker.shutdown: skipping destroy() for stage={self._params.name}; "
+                "setup incomplete, will use ray.kill() + reap."
+            )
+            return
         if timeout_s <= 0.0:
             return
 

--- a/cosmos_xenna/ray_utils/test_stage_worker_shutdown.py
+++ b/cosmos_xenna/ray_utils/test_stage_worker_shutdown.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the shutdown path in :class:`StageWorker`.
+
+Focused on the ``_call_user_stage_destroy`` guard that skips the user stage's
+``destroy()`` when setup has not signalled completion. Running ``destroy()``
+concurrently with an in-flight ``setup()`` races against the resources setup
+is still acquiring (e.g. subprocesses being spawned, sockets being
+handshaked); the guard prevents that race and defers cleanup to ``ray.kill()``
+plus the node-local pid reap.
+
+Ray is not initialised: we exercise the underlying method function against a
+``MagicMock`` self, following the same ``__wrapped__``/``__get__`` pattern used
+in ``test_stage_worker_continuous.py`` for other ``@ray.remote``-wrapped
+methods.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+import cosmos_xenna.ray_utils.stage_worker as sw_module
+
+
+def _get_destroy_impl() -> Callable[..., Any]:
+    """Return the underlying ``_call_user_stage_destroy`` function.
+
+    ``@ray.remote`` wraps ``StageWorker`` in an actor-class descriptor, so
+    static type checkers (pyright) do not see the raw class methods as
+    attributes. ``getattr`` with a string bypasses the static check while
+    still resolving the attribute at runtime. If ``@ray.method`` (or a
+    similar wrapper) has been applied, the raw function is exposed via
+    ``__wrapped__``; otherwise the attribute itself is the function.
+    """
+    # ``getattr`` (rather than attribute access) is intentional: it hides the
+    # attribute from pyright, which does not model the ``@ray.remote`` actor-
+    # class descriptor as exposing the raw class methods.
+    method = getattr(sw_module.StageWorker, "_call_user_stage_destroy")  # noqa: B009
+    return getattr(method, "__wrapped__", method)
+
+
+def _make_worker_mock(setup_completed: bool) -> MagicMock:
+    """Build a minimal ``StageWorker``-shaped mock for ``_call_user_stage_destroy``."""
+    mock = MagicMock(name="stage_worker")
+    mock._setup_completed = threading.Event()
+    if setup_completed:
+        mock._setup_completed.set()
+    mock._stage_interface = MagicMock(name="stage_interface")
+    mock._params = MagicMock(name="params")
+    mock._params.name = "test_stage"
+    return mock
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_destroy_skipped_when_setup_incomplete() -> None:
+    """``destroy()`` is not invoked when ``_setup_completed`` is not set."""
+    mock_self = _make_worker_mock(setup_completed=False)
+    call = _get_destroy_impl()
+
+    call(mock_self, 10.0)
+
+    mock_self._stage_interface.destroy.assert_not_called()
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_destroy_runs_when_setup_complete() -> None:
+    """``destroy()`` runs normally once ``_setup_completed`` is set."""
+    mock_self = _make_worker_mock(setup_completed=True)
+    call = _get_destroy_impl()
+
+    call(mock_self, 10.0)
+
+    mock_self._stage_interface.destroy.assert_called_once()
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_destroy_skipped_when_timeout_nonpositive_even_if_setup_complete() -> None:
+    """The pre-existing ``timeout_s <= 0`` short-circuit is preserved."""
+    mock_self = _make_worker_mock(setup_completed=True)
+    call = _get_destroy_impl()
+
+    call(mock_self, 0.0)
+
+    mock_self._stage_interface.destroy.assert_not_called()
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_setup_guard_takes_priority_over_timeout() -> None:
+    """The setup guard evaluates before the timeout check.
+
+    A caller passing ``timeout_s > 0`` for a mid-setup actor still gets the
+    no-op behavior; the guard is the source of truth for "is there anything
+    to destroy right now?".
+    """
+    mock_self = _make_worker_mock(setup_completed=False)
+    call = _get_destroy_impl()
+
+    call(mock_self, 45.0)
+
+    mock_self._stage_interface.destroy.assert_not_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmos-xenna"
-version = "0.5.4"
+version = "0.5.5"
 description = "A framework for building and running distributed, AI-powered data pipelines using Ray"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "cosmos-xenna"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

Skip the user stage's `destroy()` when setup has not signalled completion. Previously, if a stage transitioned to done while some of its actors were still in `stage_setup()`, `ActorPool.stop()` would run `destroy()` concurrently with the in-flight setup thread — tearing subprocesses out from under it (e.g. vLLM's mid-init `EngineCore`) and producing spurious `Engine core initialization failed` tracebacks.

## Changes

- `StageWorker.shutdown()` — skip `_call_user_stage_destroy` when `_setup_completed` is not set.
- `ActorPool.stop()` — pass `grace_period_s=0` for pending / pending-node / waiting states (no in-flight tasks to drain, and no destroy() work with the guard above; the previous drain window was a wasted thread-join wait).

## Cleanup preserved

- **Ready actors**: unchanged. Full `destroy()` (drop refs → vLLM IPC shutdown → SIGTERM/SIGKILL safety net → torch cleanup) still runs.
- **Pre-ready actors**: `ray.kill()` + `_reap_pids` node-local sweep. vLLM's IPC-closure handler in the orphaned `EngineCore` is the documented recovery path already relied on by `_kill_orphan_engine_cores` for actors that die abruptly.
