### PR TITLE
fix: keep trace fields in JSON logs regardless of import order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Latest
 
+## [0.5.6]
+
+### Fixed
+
+- Structured JSON logging (`PYTHON_LOG_FORMAT=json`) no longer drops OpenTelemetry's `trace_id` / `span_id` fields, which were silently stripped depending on import order.
+
 ## [0.5.5]
 
 ### Fixed

--- a/cosmos_xenna/utils/python_log.py
+++ b/cosmos_xenna/utils/python_log.py
@@ -122,7 +122,15 @@ _SUCCESS_LEVEL_NO = 25
 # stdlib LogRecord attribute names we must not clobber when flattening loguru
 # extras onto a forwarded record. Derived from a blank record so it tracks the
 # running Python version, plus the two names makeRecord() reserves.
-_RESERVED_LOGRECORD_ATTRS = frozenset(vars(logging.makeLogRecord({}))) | {"message", "asctime"}
+#
+# LogRecord is instantiated directly rather than via logging.makeLogRecord(), which
+# would route through logging._logRecordFactory: any factory patched in before this
+# module is first imported (e.g. OTel's logging instrumentation adding trace_id /
+# span_id) would otherwise land in this set and be silently dropped from JSON output,
+# depending on import order. Direct instantiation captures the stdlib names only.
+_RESERVED_LOGRECORD_ATTRS = frozenset(
+    vars(logging.LogRecord(name="", level=0, pathname="", lineno=0, msg="", args=(), exc_info=None))
+) | {"message", "asctime"}
 
 
 def _wants_json(value: Optional[str] = None) -> bool:

--- a/cosmos_xenna/utils/test_python_log.py
+++ b/cosmos_xenna/utils/test_python_log.py
@@ -15,6 +15,7 @@
 
 
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -333,6 +334,62 @@ def test_json_mode_emits_when_external_handler_rejects_record():
     assert "EXT:SHOULD_BE_JSON_FALLBACK" not in err
     assert err.count("EXT:SHOULD_BE_EXTERNAL") == 1
     assert err.count("SHOULD_BE_EXTERNAL") == 1
+
+
+@pytest.fixture
+def patched_record_factory():
+    """Install a record factory that adds an extra attribute, then restore the original."""
+    original = logging.getLogRecordFactory()
+
+    def factory(*args, **kwargs):
+        record = original(*args, **kwargs)
+        record.trace_id = "deadbeef"
+        return record
+
+    logging.setLogRecordFactory(factory)
+    try:
+        yield
+    finally:
+        logging.setLogRecordFactory(original)
+
+
+def test_reserved_attrs_are_independent_of_the_record_factory(patched_record_factory):
+    # _RESERVED_LOGRECORD_ATTRS must name stdlib attributes only. Deriving it via
+    # logging.makeLogRecord() routed through logging._logRecordFactory, so attributes
+    # added by a patched factory were classified as reserved and dropped from the JSON
+    # output. Assert both the set and the resulting formatter output.
+    from cosmos_xenna.utils import python_log as L
+
+    assert "trace_id" in logging.makeLogRecord({}).__dict__, "factory must be active for this test to mean anything"
+    assert "trace_id" not in L._RESERVED_LOGRECORD_ATTRS
+
+    record = logging.getLogger("t").makeRecord("t", logging.INFO, __file__, 1, "MSG", (), None)
+    assert json.loads(L._FlatJsonFormatter().format(record))["trace_id"] == "deadbeef"
+
+
+def test_json_mode_keeps_attrs_from_a_factory_patched_before_import():
+    # Regression for the import-order landmine: OTel's logging instrumentation patches
+    # the record factory to inject trace_id/span_id, and may do so before python_log is
+    # first imported in a process. Those attributes must still reach the JSON line.
+    code = (
+        "import logging\n"
+        "_old = logging.getLogRecordFactory()\n"
+        "def _factory(*args, **kwargs):\n"
+        "    record = _old(*args, **kwargs)\n"
+        "    record.trace_id = 'deadbeef'\n"
+        "    return record\n"
+        "logging.setLogRecordFactory(_factory)\n"
+        "from cosmos_xenna.utils import python_log as L\n"
+        "L.info('FACTORY_ATTR')\n"
+    )
+    err = _run_code_and_capture_stderr(
+        code,
+        {"PYTHON_LOG": "info", "PYTHON_LOG_FORMAT": "json", "POD_NAME": "pod-8"},
+        [_pkg_root()],
+    )
+    obj = _json_lines(err)[0]
+    assert obj["message"] == "FACTORY_ATTR"
+    assert obj["trace_id"] == "deadbeef"
 
 
 @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmos-xenna"
-version = "0.5.5"
+version = "0.5.6"
 description = "A framework for building and running distributed, AI-powered data pipelines using Ray"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "cosmos-xenna"
-version = "0.5.5"
+version = "0.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary
Structured JSON logging (`PYTHON_LOG_FORMAT=json`) silently dropped record attributes such as OpenTelemetry's `trace_id` / `span_id` fields, which are what make a log line linkable to its span.

`_RESERVED_LOGRECORD_ATTRS` (the set of stdlib attribute names to skip when flattening loguru extras) was derived from `logging.makeLogRecord({})`. That call routes through `logging._logRecordFactory`, so if a factory was patched in before this module was first imported, its injected fields landed in the reserved set and were stripped from JSON output. Whether that happened depended on import order, which made it look intermittent.

The set is now built from a directly constructed `logging.LogRecord`, which bypasses the factory and captures only the stdlib names.

## Changes
- `cosmos_xenna/utils/python_log.py` — build the reserved-attribute set from
  `logging.LogRecord(...)` instead of `logging.makeLogRecord({})`
- `cosmos_xenna/utils/test_python_log.py` — two regression tests: the reserved
  set is independent of the installed factory, and JSON output keeps fields
  from a factory patched before import