### PR TITLE
fix: make the JSON-mode log sink picklable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Latest
 
+## [0.5.7]
+
+### Fixed
+
+- Ray actor creation under `PYTHON_LOG_FORMAT=json` no longer fails with `cannot pickle '_thread.RLock' object` when an actor references the configured logger. The revived logger's `pod`/`replica`/`pid`/`run_id` identity fields and `seq` tiebreaker are now attributed to the process actually emitting each record, rather than frozen at whichever process created the actor.
+
 ## [0.5.6]
 
 ### Fixed

--- a/cosmos_xenna/utils/python_log.py
+++ b/cosmos_xenna/utils/python_log.py
@@ -155,18 +155,44 @@ def _node_identity() -> str:
     return os.getenv("POD_NAME") or os.getenv("SLURMD_NODENAME") or socket.gethostname() or ""
 
 
-def _identity_extra() -> dict[str, Any]:
-    """Static per-process identity fields bound to every record via logger.configure()."""
-    pod = _node_identity()
-    return {
-        "pod": pod,
+# pod/replica/run_id derive from env/hostname and do not change within a
+# configured process, so they are computed once per (re)configuration --
+# see `_refresh_static_identity_extra` -- rather than on every emitted
+# record. `pid` is deliberately NOT cached here: a process can fork after
+# configuring, and a cached pid would go stale for the child in exactly the
+# way a pickled-and-revived logger's frozen `extra` used to (see
+# `_LoguruToStdlibBridge.emit`). `os.getpid()` is a cheap syscall wrapper,
+# unlike the `socket.gethostname()` fallback in `_node_identity()`.
+_STATIC_IDENTITY_EXTRA: dict[str, str] = {"pod": "", "replica": "", "run_id": ""}
+
+
+def _refresh_static_identity_extra() -> None:
+    """Recompute the per-process identity fields that are safe to cache.
+
+    Called once per (re)configuration from `_configure_from_env`, so
+    `_identity_extra()` can read them without re-deriving them (env lookups,
+    a `socket.gethostname()` fallback) on every emitted record.
+    """
+    global _STATIC_IDENTITY_EXTRA  # noqa: PLW0603
+    _STATIC_IDENTITY_EXTRA = {
+        "pod": _node_identity(),
         # replica = k8s StatefulSet ordinal; sourced strictly from POD_NAME so it is
         # populated only on k8s/NVCF and stays "" off-k8s (SLURM/local) instead of
         # misreading a node name like pool0-0218 as a replica ordinal.
         "replica": _replica_from_pod_name(os.getenv("POD_NAME", "")),
-        "pid": os.getpid(),
         "run_id": os.getenv("CURATOR_RUN_ID", ""),
-        "seq": 0,  # placeholder; replaced per emitted record by the sink filter
+    }
+
+
+def _identity_extra() -> dict[str, Any]:
+    """Per-process identity fields bound to every record via logger.configure().
+
+    `seq` is not part of this: it is stamped once, in
+    `_LoguruToStdlibBridge.emit`, as the sole site that ticks `_SEQ_COUNTER`.
+    """
+    return {
+        **_STATIC_IDENTITY_EXTRA,
+        "pid": os.getpid(),
     }
 
 
@@ -200,6 +226,31 @@ class _LoguruToStdlibBridge(logging.Handler):
             for key, value in extra.items():
                 attr = key if key not in _RESERVED_LOGRECORD_ATTRS else f"extra_{key}"
                 record.__dict__.setdefault(attr, value)
+        # A record reaching this sink may come from a Logger that cloudpickle
+        # reconstructed in another process: __reduce__ below only makes this
+        # handler picklable, so the whole Logger -- including its `extra` --
+        # serializes by value, and a revived logger's identity fields are
+        # frozen at whichever process pickled it. Overwrite them with this
+        # process's own values so a record is attributed to whoever actually
+        # emitted it, not a snapshot of wherever the logger was created. This
+        # is a no-op for an ordinary (never-pickled) logger: its `extra`
+        # already holds this same process's identity.
+        for key, value in _identity_extra().items():
+            attr = key if key not in _RESERVED_LOGRECORD_ATTRS else f"extra_{key}"
+            record.__dict__[attr] = value
+        # `seq` is stamped here and ONLY here -- not in the loguru filter (see
+        # `_make_filter`) -- so there is exactly one tick per emitted record.
+        # `_SEQ_COUNTER` is a live module global, and this method runs as
+        # this process's own code even for a revived logger (the class is
+        # referenced, not snapshotted -- see __reduce__ below), so the value
+        # is always drawn from whoever is actually emitting. Stamping it in
+        # the filter as well as here would double-consume the counter for an
+        # ordinary logger (each record ticks twice, e.g. 1, 3, 5, ...);
+        # stamping it only in the filter is what let a revived logger's
+        # frozen closure resume counting from a stale position and collide
+        # with the live process's own stream.
+        seq_attr = "seq" if "seq" not in _RESERVED_LOGRECORD_ATTRS else "extra_seq"
+        record.__dict__[seq_attr] = next(_SEQ_COUNTER)
         logging.getLogger(record.name).handle(record)
 
     def __reduce__(self) -> tuple[type["_LoguruToStdlibBridge"], tuple[()]]:
@@ -217,6 +268,12 @@ class _LoguruToStdlibBridge(logging.Handler):
         The bridge carries no state worth moving between processes: ``emit`` only
         forwards into ``logging.getLogger(record.name)``. The receiving process
         gets a new instance with its own lock, which is what it wants anyway.
+
+        Making the handler picklable is not the end of the story: it lets the
+        *whole* ``Logger`` pickle by value (its ``_core``, including ``extra``,
+        was the only other thing standing in the way), which trades the crash
+        for a revived logger whose identity fields are frozen at the pickling
+        process's state. ``emit`` corrects that on the way out -- see there.
         """
         return (self.__class__, ())
 
@@ -370,7 +427,7 @@ def _module_path_from_record(record: Mapping[str, Any]) -> str:
     return leaf
 
 
-def _make_filter(config: _LogConfig, *, stamp_seq: bool) -> Callable[[Mapping[str, Any]], bool]:
+def _make_filter(config: _LogConfig) -> Callable[[Mapping[str, Any]], bool]:
     """
     Build and return a filter callable suitable for a Loguru sink.
 
@@ -378,9 +435,9 @@ def _make_filter(config: _LogConfig, *, stamp_seq: bool) -> Callable[[Mapping[st
     the most specific matching rule (longest matching pattern) or the default
     threshold when no pattern matches.
 
-    When ``stamp_seq`` is True (JSON mode only), the monotonic ``seq`` tiebreaker is
-    stamped onto passing records. In text mode it is left off so the record ``extra``
-    stays empty, keeping non-JSON cosmos-xenna consumers byte-for-byte unchanged.
+    This filter does not stamp `seq`: that is `_LoguruToStdlibBridge.emit`'s job,
+    and its sole job, so there is exactly one tick of `_SEQ_COUNTER` per emitted
+    record regardless of which process's code is running `emit` (see there).
     """
     level_no = {name: _logger.level(name).no for name in _LEVEL_ALIASES.values() if name != "OFF"}
     default_no = None if config.default_level_name == "OFF" else level_no[config.default_level_name]
@@ -400,13 +457,7 @@ def _make_filter(config: _LogConfig, *, stamp_seq: bool) -> Callable[[Mapping[st
         thr = select_threshold(mod)
         if thr is None:
             return False
-        if record["level"].no < thr:
-            return False
-        if stamp_seq:
-            # Stamp the monotonic seq only on records that actually pass the level
-            # filter, so it stays gap-free and acts as a timestamp-collision tiebreaker.
-            record["extra"]["seq"] = next(_SEQ_COUNTER)
-        return True
+        return record["level"].no >= thr
 
     return _filter
 
@@ -432,13 +483,17 @@ def _configure_from_env() -> None:
     # Drop any fallback handler from a prior configuration so re-config is clean and
     # text mode never leaves a stray JSON handler behind.
     _remove_fallback_root_handler()
+    # Refresh the cached static identity fields on every (re)configuration --
+    # e.g. a test monkeypatching POD_NAME and calling ensure_configured(force=True)
+    # -- so _identity_extra() never serves a value from a prior configuration.
+    _refresh_static_identity_extra()
     # Only bind identity extras in JSON mode. In text mode reset to an empty extra so
     # behavior matches the pre-structured-logging default for other xenna consumers.
     # Bind via extra (not patcher) so logger.patch() chains such as make_tagged_logger()
     # keep working while these fields ride on every record.
     _logger.configure(extra=_identity_extra() if json_mode else {})
     config = _parse_env(env)
-    filt = _make_filter(config, stamp_seq=json_mode)
+    filt = _make_filter(config)
     if json_mode:
         _install_stdlib_level_names()
         # format="{message}" keeps the raw (tag-prefixed) message so the downstream

--- a/cosmos_xenna/utils/python_log.py
+++ b/cosmos_xenna/utils/python_log.py
@@ -202,6 +202,24 @@ class _LoguruToStdlibBridge(logging.Handler):
                 record.__dict__.setdefault(attr, value)
         logging.getLogger(record.name).handle(record)
 
+    def __reduce__(self) -> tuple[type["_LoguruToStdlibBridge"], tuple[()]]:
+        """Rebuild a fresh bridge rather than pickling this one.
+
+        ``@ray.remote`` rebinds the decorated class, which defeats cloudpickle's
+        by-reference lookup and makes it serialize actor classes *by value* --
+        pickling every global the actor's methods reference. A module-level
+        ``from loguru import logger`` therefore drags loguru's installed sinks
+        along, and in JSON mode this handler is one of them. ``logging.Handler``
+        holds a ``threading.RLock``, so without this, actor creation dies with
+        "cannot pickle '_thread.RLock' object" -- at runtime, inside the deployed
+        job, with nothing failing at build time.
+
+        The bridge carries no state worth moving between processes: ``emit`` only
+        forwards into ``logging.getLogger(record.name)``. The receiving process
+        gets a new instance with its own lock, which is what it wants anyway.
+        """
+        return (self.__class__, ())
+
 
 class _FlatJsonFormatter(logging.Formatter):
     """Render a stdlib ``LogRecord`` as a single flat JSON object.

--- a/cosmos_xenna/utils/test_python_log.py
+++ b/cosmos_xenna/utils/test_python_log.py
@@ -629,3 +629,214 @@ def test_configured_logger_survives_by_value_actor_pickling(log_format):
     assert "cannot pickle" not in err, err
     assert "Traceback" not in err, err
     assert "DUMPED" in err, err
+
+
+def test_bridge_emit_corrects_identity_and_stamps_seq_fresh(monkeypatch):
+    """``emit`` overwrites identity fields and is the sole ``seq``-stamping site.
+
+    Making the bridge picklable lets cloudpickle serialize the *whole* Logger
+    by value (only its handlers were blocking it before), so a revived
+    logger's ``extra`` -- including pod/replica/pid/run_id -- is frozen at
+    whichever process pickled it, and a revived logger's filter closure
+    resumes ``seq`` from a frozen, disconnected counter position, colliding
+    with the live process's own stream at the same pid. ``emit`` corrects
+    both: identity fields are overwritten from this process's own state
+    (cached pod/replica/run_id, live pid), and ``seq`` is always drawn fresh
+    from the live ``_SEQ_COUNTER`` -- never taken from ``record.extra`` --
+    which is what makes a single tick per emitted record possible regardless
+    of whether the logger emitting it was ever pickled.
+    """
+    from cosmos_xenna.utils import python_log as L
+
+    monkeypatch.setenv("POD_NAME", "real-pod-7")
+    monkeypatch.setenv("CURATOR_RUN_ID", "real-run")
+    # The cached pod/replica/run_id fields refresh on (re)configuration, not on
+    # every call -- see _refresh_static_identity_extra -- so picking up the env
+    # change above needs an explicit refresh, matching what _configure_from_env
+    # does on a real (re)configure.
+    L._refresh_static_identity_extra()
+
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    logger_name = "bridge-emit-identity-test"
+    target = logging.getLogger(logger_name)
+    target.addHandler(_Capture())
+    target.setLevel(logging.DEBUG)
+
+    def _make_stale_record(msg: str) -> logging.LogRecord:
+        record = logging.LogRecord(
+            name=logger_name,
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+        # Shape a revived logger's frozen closure could plausibly produce: a
+        # driver's identity, and a seq resumed from wherever its counter was
+        # pickled -- not necessarily lower than this process's own position.
+        record.extra = {
+            "pod": "stale-driver-pod",
+            "replica": "stale-replica",
+            "pid": -1,
+            "run_id": "stale-run",
+            "seq": 999,
+        }
+        return record
+
+    bridge = L._LoguruToStdlibBridge()
+    bridge.emit(_make_stale_record("first"))
+    bridge.emit(_make_stale_record("second"))
+
+    assert len(captured) == 2
+    first, second = captured
+    # Read via __dict__, not dot access: these are dynamic attributes emit()
+    # sets on the record (see python_log.py), not declared LogRecord fields --
+    # pyright can't see them through the append/index round-trip via `captured`.
+    assert first.__dict__["pod"] == "real-pod-7"
+    assert first.__dict__["pid"] == os.getpid()
+    assert first.__dict__["run_id"] == "real-run"
+    # Never taken from record.extra (999 above) -- always the live counter.
+    assert first.__dict__["seq"] != 999
+    # Exactly one tick per emitted record: gap-free across two calls.
+    assert second.__dict__["seq"] == first.__dict__["seq"] + 1
+
+
+_FORK_REVIVED_LOGGER_CODE = """
+import ray.cloudpickle as cloudpickle
+from loguru import logger
+
+data = cloudpickle.dumps(logger)
+
+r, w = os.pipe()
+child_pid = os.fork()
+if child_pid == 0:
+    os.close(r)
+    revived = cloudpickle.loads(data)
+    os.dup2(w, 2)
+    revived.info('FROMCHILD')
+    sys.stderr.flush()
+    os._exit(0)
+os.close(w)
+os.waitpid(child_pid, 0)
+output = os.read(r, 65536).decode()
+print(output, file=sys.stderr)
+print(json.dumps({'child_pid': child_pid}), file=sys.stderr)
+"""
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_revived_logger_reports_the_emitting_process_pid():
+    """Regression test for the exact bug this pins: a genuine cross-process pickle.
+
+    Cloudpickle a configured JSON-mode logger in one process, revive it in a
+    *forked* child with a different real pid, and confirm the emitted record
+    carries the child's pid -- not the parent's, frozen at pickling time. This
+    exercises the real mechanism (fork gives an unambiguous, genuinely
+    different pid) rather than approximating it.
+    """
+    code = (
+        _JSON_ROOT_PREAMBLE
+        + "import os, sys, json\n"
+        + "from cosmos_xenna.utils import python_log as L\n"
+        + _FORK_REVIVED_LOGGER_CODE
+    )
+    err = _run_code_and_capture_stderr(
+        code,
+        {
+            "PYTHON_LOG": "info",
+            "PYTHON_LOG_FORMAT": "json",
+            "POD_NAME": "driver-pod-0",
+            "CURATOR_RUN_ID": "run-xyz",
+        },
+        [_pkg_root()],
+    )
+
+    objs = _json_lines(err)
+    child_pid_obj = next(o for o in objs if "child_pid" in o)
+    from_child = next(o for o in objs if o.get("message") == "FROMCHILD")
+
+    assert from_child["pid"] == child_pid_obj["child_pid"]
+    assert from_child["pod"] == "driver-pod-0"
+
+
+_FORK_SEQ_COLLISION_CODE = """
+import ray.cloudpickle as cloudpickle
+from loguru import logger
+
+# Advance the driver's counter before pickling, simulating a driver that has
+# already been logging for a while -- this is what let a revived logger's
+# frozen closure resume counting from a stale, nonzero position.
+for _ in range(500):
+    next(L._SEQ_COUNTER)
+
+data = cloudpickle.dumps(logger)
+
+r, w = os.pipe()
+child_pid = os.fork()
+if child_pid == 0:
+    os.close(r)
+    os.dup2(w, 2)
+    revived = cloudpickle.loads(data)
+    # Interleave native (this process's own configured logger) and revived
+    # (unpickled) emissions -- the exact shape that used to produce two
+    # independent seq lineages sharing one pid.
+    L.info('native-1')
+    revived.info('revived-1')
+    revived.info('revived-2')
+    L.info('native-2')
+    revived.info('revived-3')
+    L.info('native-3')
+    sys.stderr.flush()
+    os._exit(0)
+os.close(w)
+os.waitpid(child_pid, 0)
+output = os.read(r, 65536).decode()
+print(output, file=sys.stderr)
+"""
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_revived_logger_seq_does_not_collide_with_native_stream():
+    """Regression test for the exact collision this pins.
+
+    Cloudpickle a JSON-mode logger after its counter has already advanced (as
+    a driver's would after logging for a while), revive it in a forked child,
+    and interleave native and revived emissions from that one pid. Before
+    moving seq-stamping into `emit` as the sole site, the revived logger's
+    filter closure resumed counting from its own frozen snapshot, so the two
+    streams produced duplicate seq values under the same pid -- exactly what
+    `seq` exists to prevent.
+    """
+    code = (
+        _JSON_ROOT_PREAMBLE
+        + "import os, sys\n"
+        + "from cosmos_xenna.utils import python_log as L\n"
+        + _FORK_SEQ_COLLISION_CODE
+    )
+    err = _run_code_and_capture_stderr(
+        code,
+        {
+            "PYTHON_LOG": "info",
+            "PYTHON_LOG_FORMAT": "json",
+            "POD_NAME": "driver-pod-0",
+            "CURATOR_RUN_ID": "run-xyz",
+        },
+        [_pkg_root()],
+    )
+
+    objs = _json_lines(err)
+    messages = {o["message"] for o in objs}
+    expected = {"native-1", "revived-1", "revived-2", "native-2", "revived-3", "native-3"}
+    assert messages == expected, err
+
+    seqs = [o["seq"] for o in objs]
+    assert len(seqs) == len(set(seqs)), f"duplicate seq values across native/revived streams: {seqs}"
+    # Single counter, single stamp site: strictly increasing across both
+    # streams, not just within each one -- the gap-free guarantee restored.
+    assert seqs == sorted(seqs), seqs

--- a/cosmos_xenna/utils/test_python_log.py
+++ b/cosmos_xenna/utils/test_python_log.py
@@ -17,6 +17,7 @@
 import json
 import logging
 import os
+import pickle
 import subprocess
 import sys
 from pathlib import Path
@@ -571,3 +572,60 @@ def test_ray_handoff_respects_log_to_driver_override(monkeypatch):
     finally:
         monkeypatch.setenv("PYTHON_LOG_FORMAT", "text")
         L.ensure_configured(force=True)
+
+
+# ---------- Serializability across the Ray actor boundary ----------
+
+
+def test_loguru_stdlib_bridge_reconstructs_on_unpickle():
+    """The JSON-mode sink must pickle; ``logging.Handler`` holds an unpicklable lock."""
+    from cosmos_xenna.utils import python_log as L
+
+    bridge = L._LoguruToStdlibBridge()
+    revived = pickle.loads(pickle.dumps(bridge))
+
+    assert isinstance(revived, L._LoguruToStdlibBridge)
+    # A fresh instance with its own lock, not a copy of the original's state.
+    assert revived is not bridge
+
+
+# The class is defined in the child's ``__main__``, which is what makes cloudpickle
+# serialize it *by value* -- the same path ``@ray.remote`` forces for actor classes.
+# cloudpickle walks only the globals a method actually names, so ``run`` has to
+# genuinely reference ``logger``: drop that line and this test stops covering anything.
+_PICKLE_ACTOR_CODE = """
+import ray.cloudpickle as cloudpickle
+from loguru import logger
+
+from cosmos_xenna.utils import python_log as L
+
+
+class Actorish:
+    def run(self):
+        logger.info('inside the actor')
+
+
+cloudpickle.dumps(Actorish)
+L.info('DUMPED')
+"""
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
+def test_configured_logger_survives_by_value_actor_pickling(log_format):
+    """An actor class reaching the configured logger must still cloudpickle.
+
+    Regression test for actor creation dying with "cannot pickle '_thread.RLock'
+    object" under ``PYTHON_LOG_FORMAT=json``: the bridge sink is a
+    ``logging.Handler``, and by-value actor serialization drags the logger's whole
+    sink set along. Text mode is covered too so a future sink cannot reintroduce
+    this on the default path.
+    """
+    err = _run_code_and_capture_stderr(
+        _JSON_ROOT_PREAMBLE + _PICKLE_ACTOR_CODE,
+        {"PYTHON_LOG": "info", "PYTHON_LOG_FORMAT": log_format},
+        [_pkg_root()],
+    )
+
+    assert "cannot pickle" not in err, err
+    assert "Traceback" not in err, err
+    assert "DUMPED" in err, err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmos-xenna"
-version = "0.5.6"
+version = "0.5.7"
 description = "A framework for building and running distributed, AI-powered data pipelines using Ray"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "cosmos-xenna"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
In JSON mode _configure_from_env installs _LoguruToStdlibBridge as a loguru
sink. It subclasses logging.Handler, whose __init__ creates a threading.RLock,
so the configured logger cannot be pickled at all: any code that serializes an
object reaching a module-level `from loguru import logger` fails with "cannot
pickle '_thread.RLock' object". Text mode is unaffected, since that sink is
sys.stderr.

Ray is where this bites in practice. @ray.remote defeats cloudpickle's
by-reference lookup and serializes actor classes by value, pickling every
global their methods reference, so actor creation dies at runtime with nothing
failing at build time. The bridge is stateless, emit only forwards into
logging.getLogger(record.name), so __reduce__ rebuilds a fresh instance in the
receiving process instead of trying to move the lock.