### PR TITLE
fix: exit stage workers and monitors cleanly under Ray 2.57 cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Latest
 
+## [0.5.9]
+
+### Changed
+
+- Raised the minimum supported Ray version from 2.56.0 to 2.57.0.
+
+### Fixed
+
+- Stage workers and resource monitors now exit reliably under Ray 2.57, which enables `process_group_cleanup_enabled` by default and waits for a worker to exit rather than force-killing it. Their loops ran on non-daemon threads whose stop flag was never set, so interpreter shutdown blocked, pipelines stalled, and actors were repeatedly recreated.
+
 ## [0.5.8]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 ## [0.5.9]
 
-### Changed
-
-- Raised the minimum supported Ray version from 2.56.0 to 2.57.0.
-
 ### Fixed
 
 - Stage workers and resource monitors now exit reliably under Ray 2.57, which enables `process_group_cleanup_enabled` by default and waits for a worker to exit rather than force-killing it. Their loops ran on non-daemon threads whose stop flag was never set, so interpreter shutdown blocked, pipelines stalled, and actors were repeatedly recreated.

--- a/cosmos_xenna/pipelines/private/monitoring.py
+++ b/cosmos_xenna/pipelines/private/monitoring.py
@@ -74,6 +74,10 @@ from cosmos_xenna.utils import timing
 from cosmos_xenna.utils.verbosity import VerbosityLevel
 
 _GPU_ORPHAN_SCAN_INTERVAL_S = 30
+# Per-thread budget for NodeResourceMonitor.stop() to observe the stop event.
+_MONITOR_THREAD_JOIN_TIMEOUT_S = 5.0
+# Budget for the driver-side ``stop()`` RPC to each per-node monitor actor.
+_MONITOR_STOP_RPC_TIMEOUT_S = 15.0
 
 
 def _get_live_ray_pids_on_node(node_id: str) -> set[int]:
@@ -128,7 +132,12 @@ class NodeResourceMonitor:
         self._stop_event = threading.Event()
         self._pynvml: Any | None = None
         self._nvml_handles: list[Any] | None = None
-        self._thread = threading.Thread(target=self._metrics_loop)
+        # daemon=True so a monitor that is killed rather than stopped can still finalize
+        # its interpreter. Ray 2.57 enables ``process_group_cleanup_enabled`` by default
+        # and the raylet waits for a gracefully-disconnecting worker to exit before
+        # sweeping its process group, so a monitor wedged in ``threading._shutdown()``
+        # survives indefinitely while its metrics loop keeps scanning the process table.
+        self._thread = threading.Thread(target=self._metrics_loop, daemon=True)
         self._thread.start()
         self._orphan_thread: threading.Thread | None = None
         if HAS_NVML:
@@ -149,9 +158,9 @@ class NodeResourceMonitor:
             sleeper.sleep()
 
     def _orphan_scan_loop(self) -> None:
-        sleeper = timing.RateLimiter(1.0 / _GPU_ORPHAN_SCAN_INTERVAL_S)
-        while not self._stop_event.is_set():
-            sleeper.sleep()
+        # ``Event.wait`` doubles as the scan interval and returns True once stopped, so
+        # ``stop()`` is not left waiting out a full 30 s sleep.
+        while not self._stop_event.wait(_GPU_ORPHAN_SCAN_INTERVAL_S):
             try:
                 self._scan_gpu_orphans()
             except Exception as e:  # noqa: BLE001
@@ -211,6 +220,23 @@ class NodeResourceMonitor:
             raise Exception(f"Error in metrics collection: {self._exception}")
         return self._latest_metrics
 
+    def stop(self) -> None:
+        """Signal the background loops to exit and join them with a bounded budget.
+
+        Without this, ``_stop_event`` was never set anywhere and the metrics loop kept
+        scanning the whole process table once a second for the lifetime of the process.
+        """
+        self._stop_event.set()
+        for name, thread in (("metrics", self._thread), ("orphan-scan", self._orphan_thread)):
+            if thread is None:
+                continue
+            thread.join(timeout=_MONITOR_THREAD_JOIN_TIMEOUT_S)
+            if thread.is_alive():
+                logger.warning(
+                    f"NodeResourceMonitor({self._node_ip}): {name} thread did not exit within "
+                    f"{_MONITOR_THREAD_JOIN_TIMEOUT_S:.1f}s; it is a daemon thread and will not block exit."
+                )
+
 
 class RayResourceMonitor:
     """A class which starts up starts up a NodeResourceMonitor on each node and collect stats from them."""
@@ -233,6 +259,26 @@ class RayResourceMonitor:
         for node_id, result in zip(self._node_ids, results, strict=True):
             out[node_id] = result
         return out
+
+    def stop(self) -> None:
+        """Stop and kill every per-node monitor actor.
+
+        These actors were previously never torn down, so each one outlived its pipeline
+        burning CPU on process-table scans. Best-effort and idempotent: this runs during
+        pipeline shutdown when Ray itself may already be going away, so an unreachable
+        actor is logged rather than raised.
+        """
+        for node_id, monitor in zip(self._node_ids, self._monitors, strict=True):
+            try:
+                ray.get(monitor.stop.remote(), timeout=_MONITOR_STOP_RPC_TIMEOUT_S)  # type: ignore
+            except Exception as e:  # noqa: BLE001 - teardown is best-effort
+                logger.warning(f"Failed to stop NodeResourceMonitor on node {node_id}: {e}")
+            try:
+                ray.kill(monitor)  # type: ignore
+            except Exception as e:  # noqa: BLE001 - teardown is best-effort
+                logger.warning(f"Failed to kill NodeResourceMonitor on node {node_id}: {e}")
+        self._monitors.clear()
+        self._node_ids.clear()
 
 
 def get_ray_actors(state: str = "ALIVE") -> List[ActorInfo]:
@@ -493,6 +539,8 @@ class PipelineMonitor:
 
     def close(self) -> None:
         assert self._opened
+        self._opened = False
+        self._nodes_resource_monitor.stop()
 
     def _create_ray_metrics(self) -> None:
         self._metrics_input_tasks = Gauge(

--- a/cosmos_xenna/pipelines/private/streaming.py
+++ b/cosmos_xenna/pipelines/private/streaming.py
@@ -18,12 +18,13 @@ from __future__ import annotations
 
 import collections
 import concurrent.futures
+import contextlib
 import math
 import queue as python_queue
 import random
 import time
 import typing
-from typing import Optional
+from typing import Callable, Iterator, Optional
 
 import attrs
 import ray
@@ -957,6 +958,39 @@ def _upstream_queue_lens(input_queue: Queue, queues: list[Queue], num_pools: int
     return [len(input_queue) if idx == 0 else len(queues[idx - 1]) for idx in range(num_pools)]
 
 
+@contextlib.contextmanager
+def _pool_stopper(pools: list[actor_pool.ActorPool]) -> Iterator[Callable[[int], None]]:
+    """Yield a ``stop_pool(idx)`` callable which stops any still-running pool on exit.
+
+    The streaming loop leaves through several routes and only one of them - the per-stage
+    "stage is done" cascade - used to stop its pools. SERVING mode's ``None`` sentinel, the
+    all-stages-done break and any propagating exception all left actors alive, and neither
+    ``Autoscaler.__exit__`` nor ``PipelineMonitor.__exit__`` touches actor pools. Ray 2.57
+    enables ``process_group_cleanup_enabled`` by default, so the raylet waits on a
+    disconnecting worker to exit before sweeping its process group; surviving actors wedge
+    teardown instead of being reaped.
+
+    Each pool is stopped exactly once, and failures are logged rather than raised so
+    teardown cannot mask an in-flight exception.
+    """
+    stopped: set[int] = set()
+
+    def stop_pool(idx: int) -> None:
+        if idx in stopped:
+            return
+        stopped.add(idx)
+        try:
+            pools[idx].stop()
+        except Exception:  # noqa: BLE001 - teardown is best-effort
+            logger.exception(f"Failed to stop actor pool {pools[idx].name}")
+
+    try:
+        yield stop_pool
+    finally:
+        for idx in range(len(pools)):
+            stop_pool(idx)
+
+
 def run_pipeline(
     pipeline_spec: specs.PipelineSpec,
     cluster_resources: resources.ClusterResources,
@@ -1025,6 +1059,9 @@ def run_pipeline(
             pools,
             pipeline_spec.config.monitoring_verbosity_level,
         ) as monitor,
+        # Entered last so it exits first: pools are stopped before the monitor's final
+        # stats pass, matching the ordering of the in-loop done cascade.
+        _pool_stopper(pools) as stop_pool,
     ):
         # This is the loop which does all the interesting stuff. It was difficult to find the correct way to iterate
         # through this which managed backpressure the correct way.
@@ -1212,7 +1249,7 @@ def run_pipeline(
                 if is_done:
                     stage_is_dones[idx] = True
                     logger.info(f"Stopping stages {idx}")
-                    pool.stop()
+                    stop_pool(idx)
                 else:
                     break
 

--- a/cosmos_xenna/pipelines/private/test_monitoring_shutdown.py
+++ b/cosmos_xenna/pipelines/private/test_monitoring_shutdown.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the monitoring-actor teardown path.
+
+``NodeResourceMonitor`` had no shutdown path at all: its ``_stop_event`` was checked by
+both background loops but never set anywhere, and ``RayResourceMonitor`` never tore down
+the actors it created. A leaked monitor scans the whole process table once a second
+forever, and under Ray 2.57's default ``process_group_cleanup_enabled`` the raylet waits
+for a gracefully-disconnecting worker to exit before sweeping its process group, so such a
+monitor is never reaped.
+
+Ray is not initialised: the underlying method functions are exercised against a
+``MagicMock`` self, following the ``__wrapped__``/``__get__`` pattern used in
+``cosmos_xenna/ray_utils/test_stage_worker_shutdown.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+import cosmos_xenna.pipelines.private.monitoring as monitoring
+
+_JOIN_TIMEOUT_S = 5.0
+
+
+def _get_impl(owner: Any, name: str) -> Callable[..., Any]:
+    """Return the raw function behind a method on a ``@ray.remote``-wrapped class.
+
+    ``@ray.remote`` replaces the class with an actor-class descriptor whose own
+    ``__init__`` constructs an actor, so the original methods are reached via
+    ``__ray_metadata__.modified_class``. Ray's tracing decorator then exposes each
+    underlying function as ``__wrapped__``.
+    """
+    cls = getattr(owner, "__ray_metadata__", None)
+    method = getattr(cls.modified_class if cls is not None else owner, name)
+    return getattr(method, "__wrapped__", method)
+
+
+def _spawn_stoppable_loop(stop_event: threading.Event) -> tuple[threading.Thread, threading.Event]:
+    """Start a daemon thread that runs until ``stop_event`` fires, plus an exit witness."""
+    exited = threading.Event()
+
+    def loop() -> None:
+        while not stop_event.wait(0.01):
+            pass
+        exited.set()
+
+    thread = threading.Thread(target=loop, daemon=True)
+    thread.start()
+    return thread, exited
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_node_monitor_stop_sets_event_and_joins_threads() -> None:
+    """``stop()`` ends both background loops and waits for them."""
+    mock_self = MagicMock(name="node_resource_monitor")
+    mock_self._node_ip = "127.0.0.1"
+    mock_self._stop_event = threading.Event()
+    mock_self._thread, metrics_exited = _spawn_stoppable_loop(mock_self._stop_event)
+    mock_self._orphan_thread, orphan_exited = _spawn_stoppable_loop(mock_self._stop_event)
+
+    _get_impl(monitoring.NodeResourceMonitor, "stop")(mock_self)
+
+    assert mock_self._stop_event.is_set()
+    assert metrics_exited.is_set()
+    assert orphan_exited.is_set()
+    assert not mock_self._thread.is_alive()
+    assert not mock_self._orphan_thread.is_alive()
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_node_monitor_stop_tolerates_absent_orphan_thread() -> None:
+    """The orphan thread only exists when NVML is available, so ``None`` must be fine."""
+    mock_self = MagicMock(name="node_resource_monitor")
+    mock_self._node_ip = "127.0.0.1"
+    mock_self._stop_event = threading.Event()
+    mock_self._thread, metrics_exited = _spawn_stoppable_loop(mock_self._stop_event)
+    mock_self._orphan_thread = None
+
+    _get_impl(monitoring.NodeResourceMonitor, "stop")(mock_self)
+
+    assert metrics_exited.is_set()
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_metrics_thread_is_daemon() -> None:
+    """A non-daemon metrics thread blocks interpreter finalization forever."""
+    mock_self = MagicMock(name="node_resource_monitor")
+    with (
+        mock.patch.object(monitoring.ray, "get_runtime_context"),
+        mock.patch.object(monitoring.ray.util, "get_node_ip_address", return_value="127.0.0.1"),
+    ):
+        _get_impl(monitoring.NodeResourceMonitor, "__init__")(mock_self)
+
+    thread = mock_self._thread
+    assert isinstance(thread, threading.Thread)
+    assert thread.daemon is True
+    mock_self._stop_event.set()
+    thread.join(timeout=_JOIN_TIMEOUT_S)
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_orphan_scan_loop_exits_without_waiting_out_its_interval() -> None:
+    """The scan interval is an interruptible wait, so ``stop()`` is not blocked ~30 s."""
+    mock_self = MagicMock(name="node_resource_monitor")
+    mock_self._stop_event = threading.Event()
+
+    thread = threading.Thread(
+        target=_get_impl(monitoring.NodeResourceMonitor, "_orphan_scan_loop"),
+        args=(mock_self,),
+        daemon=True,
+    )
+    thread.start()
+    mock_self._stop_event.set()
+    thread.join(timeout=_JOIN_TIMEOUT_S)
+
+    assert not thread.is_alive()
+    mock_self._scan_gpu_orphans.assert_not_called()
+
+
+def _make_ray_monitor_mock(num_nodes: int) -> MagicMock:
+    mock_self = MagicMock(name="ray_resource_monitor")
+    mock_self._node_ids = [f"node-{idx}" for idx in range(num_nodes)]
+    mock_self._monitors = [MagicMock(name=f"monitor-{idx}") for idx in range(num_nodes)]
+    return mock_self
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_ray_monitor_stop_stops_then_kills_every_actor() -> None:
+    """Every per-node actor gets a graceful ``stop()`` followed by a ``ray.kill()``."""
+    mock_self = _make_ray_monitor_mock(3)
+    monitors = list(mock_self._monitors)
+
+    with (
+        mock.patch.object(monitoring.ray, "get") as ray_get,
+        mock.patch.object(monitoring.ray, "kill") as ray_kill,
+    ):
+        _get_impl(monitoring.RayResourceMonitor, "stop")(mock_self)
+
+    assert ray_get.call_count == 3
+    assert [call.args[0] for call in ray_kill.call_args_list] == monitors
+    for monitor in monitors:
+        monitor.stop.remote.assert_called_once()
+    # Cleared so a second stop() (e.g. close() then __exit__) is a no-op.
+    assert not mock_self._monitors
+    assert not mock_self._node_ids
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_ray_monitor_stop_swallows_unreachable_actors() -> None:
+    """Teardown runs while Ray may already be going away, so it must not raise."""
+    mock_self = _make_ray_monitor_mock(2)
+    monitors = list(mock_self._monitors)
+
+    with (
+        mock.patch.object(monitoring.ray, "get", side_effect=RuntimeError("gcs is gone")),
+        mock.patch.object(monitoring.ray, "kill", side_effect=RuntimeError("gcs is gone")) as ray_kill,
+    ):
+        _get_impl(monitoring.RayResourceMonitor, "stop")(mock_self)
+
+    # A failure on the first actor must not skip the rest.
+    assert ray_kill.call_count == len(monitors)
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_pipeline_monitor_close_stops_the_node_monitors() -> None:
+    """``close()`` was a bare assert, so the actors it opened were never torn down."""
+    mock_self = MagicMock(name="pipeline_monitor")
+    mock_self._opened = True
+
+    monitoring.PipelineMonitor.close(mock_self)
+
+    mock_self._nodes_resource_monitor.stop.assert_called_once_with()
+    assert mock_self._opened is False

--- a/cosmos_xenna/pipelines/private/test_streaming.py
+++ b/cosmos_xenna/pipelines/private/test_streaming.py
@@ -17,10 +17,11 @@
 import collections
 import random
 from typing import Any, List, Optional
+from unittest.mock import MagicMock
 
 import pytest
 
-from cosmos_xenna.pipelines.private.streaming import Queue
+from cosmos_xenna.pipelines.private.streaming import Queue, _pool_stopper
 from cosmos_xenna.ray_utils.actor_pool import Task as ActualTask
 
 
@@ -302,3 +303,56 @@ class TestQueue:
         all_retrieved = batch1.task_data + batch2.task_data + remaining_samples
         assert set(all_retrieved) == {1, 2, 3, 4, 5, 6}
         assert q.avg_samples_per_task() == 2.0  # Still unchanged
+
+
+class TestPoolStopper:
+    """Every exit from the streaming loop must stop all actor pools exactly once.
+
+    Only the per-stage "stage is done" cascade used to call ``pool.stop()``; SERVING mode's
+    ``None`` sentinel, the all-stages-done break and any propagating exception all left
+    actors alive. Under Ray 2.57's default ``process_group_cleanup_enabled`` the raylet
+    waits for a disconnecting worker to exit before sweeping its process group, so
+    surviving actors wedge teardown.
+    """
+
+    @staticmethod
+    def _pools(count: int) -> list[Any]:
+        pools = []
+        for idx in range(count):
+            pool = MagicMock(name=f"pool-{idx}")
+            pool.name = f"stage-{idx}"
+            pools.append(pool)
+        return pools
+
+    def test_stops_pools_never_stopped_in_the_loop(self):
+        pools = self._pools(3)
+        with _pool_stopper(pools):
+            pass  # e.g. SERVING mode's None sentinel: no stage was ever marked done.
+        for pool in pools:
+            pool.stop.assert_called_once_with()
+
+    def test_does_not_double_stop_pools_stopped_in_the_loop(self):
+        pools = self._pools(3)
+        with _pool_stopper(pools) as stop_pool:
+            stop_pool(0)
+            stop_pool(1)
+            stop_pool(1)  # A repeat request is also a no-op.
+        for pool in pools:
+            pool.stop.assert_called_once_with()
+
+    def test_stops_pools_when_an_exception_propagates(self):
+        pools = self._pools(2)
+        with pytest.raises(ValueError, match="boom"), _pool_stopper(pools):
+            raise ValueError("boom")
+        for pool in pools:
+            pool.stop.assert_called_once_with()
+
+    def test_a_failing_stop_neither_masks_the_exception_nor_skips_other_pools(self):
+        pools = self._pools(3)
+        pools[0].stop.side_effect = RuntimeError("actor is unreachable")
+
+        with pytest.raises(ValueError, match="boom"), _pool_stopper(pools):
+            raise ValueError("boom")
+
+        for pool in pools:
+            pool.stop.assert_called_once_with()

--- a/cosmos_xenna/ray_utils/stage_worker.py
+++ b/cosmos_xenna/ray_utils/stage_worker.py
@@ -66,6 +66,7 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import atexit
 import copy
 import os
 import queue
@@ -193,6 +194,19 @@ class _ProcessDataResult(Generic[V]):
     pool_info: FailureInfo
 
 
+def _signal_stop_at_exit(stop_flag: threading.Event) -> None:
+    """``atexit`` hook which breaks the worker loops on any interpreter exit path.
+
+    Takes the ``Event`` rather than the worker so the registration cannot keep the
+    actor (and the user stage it holds) alive. Never raises: this runs during
+    interpreter teardown, where an exception would be printed and ignored anyway.
+    """
+    try:
+        stop_flag.set()
+    except Exception:  # noqa: BLE001 - teardown must not raise
+        pass
+
+
 def _get_object_size(ref: ray.ObjectRef) -> int:
     """Gets the size of an object store in Ray's object store."""
     # Get object locations
@@ -280,13 +294,37 @@ class StageWorker(abc.ABC, Generic[T, V]):
         self._setup_on_node_completed = threading.Event()
         self._setup_on_node_error: Exception | None = None
 
-        self._downloader_thread = threading.Thread(target=self._downloader_loop)
+        # All three loops spin until ``stop_flag`` is set, and ``shutdown()`` used to be
+        # the only thing that set it. Every other way this actor can go away - SIGTERM at
+        # cluster teardown, the handle going out of scope, ``ray.actor.exit_actor()`` from
+        # user stage code - therefore left the threads looping and CPython's
+        # ``threading._shutdown()`` blocking forever joining them. Ray 2.57 turned that
+        # from a slow exit into a hang: with ``process_group_cleanup_enabled`` on by
+        # default the raylet polls for a gracefully-disconnecting worker to exit before
+        # sweeping its process group, on the assumption that a worker which never exits is
+        # a bug.
+        #
+        # ``daemon=True`` is what fixes that, and the ``atexit`` hook cannot substitute for
+        # it: ``Py_FinalizeEx`` joins non-daemon threads *before* running ``atexit``
+        # handlers, so a hook that sets ``stop_flag`` never gets the chance to run. Once the
+        # threads are daemons the hook does become useful - it fires while they are still
+        # alive, letting each loop leave on its own terms instead of being torn down
+        # mid-iteration.
+        #
+        # ``daemon=True`` cannot lose results a caller is still awaiting: it only changes
+        # interpreter finalization, which the actor process reaches solely on its way out,
+        # at which point in-flight ``process_data`` results are unreachable regardless.
+        # The graceful path is unaffected - ``shutdown()`` still joins all three threads
+        # within its budget before returning, and ``Thread.join`` ignores the daemon flag.
+        atexit.register(_signal_stop_at_exit, self.stop_flag)
+
+        self._downloader_thread = threading.Thread(target=self._downloader_loop, daemon=True)
         self._downloader_thread.start()
 
-        self._deserializer_thread = threading.Thread(target=self._deserializer_loop)
+        self._deserializer_thread = threading.Thread(target=self._deserializer_loop, daemon=True)
         self._deserializer_thread.start()
 
-        self._process_data_thread = threading.Thread(target=self._process_data_loop)
+        self._process_data_thread = threading.Thread(target=self._process_data_loop, daemon=True)
         self._process_data_thread.start()
 
         self._error_map: dict[str, Exception] = {}

--- a/cosmos_xenna/ray_utils/test_stage_worker_daemon_threads.py
+++ b/cosmos_xenna/ray_utils/test_stage_worker_daemon_threads.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for :class:`StageWorker`'s ability to always reach process exit.
+
+Ray 2.57 enables ``process_group_cleanup_enabled`` by default: each worker becomes its
+own process-group leader and, on a graceful disconnect, the raylet polls for the worker
+process to exit before sweeping the group. A worker that never finishes interpreter
+shutdown therefore survives forever. ``StageWorker``'s three loop threads only exit on
+``stop_flag``, which used to be set exclusively by ``shutdown()``, so every other exit
+route (SIGTERM, handle going out of scope, ``ray.actor.exit_actor()``) left CPython's
+``threading._shutdown()`` blocking on the joins.
+
+These tests pin the two properties that fix it: the loop threads are daemons, and an
+``atexit`` hook sets ``stop_flag`` so the loops also stop cooperatively.
+
+Ray is not initialised: the underlying method functions are exercised against a
+``MagicMock`` self, following the ``__wrapped__``/``__get__`` pattern already used in
+``test_stage_worker_shutdown.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+import cosmos_xenna.ray_utils.stage_worker as sw_module
+
+_THREAD_NAMES = ("_downloader_thread", "_deserializer_thread", "_process_data_thread")
+_JOIN_TIMEOUT_S = 5.0
+
+
+def _get_impl(name: str) -> Callable[..., Any]:
+    """Return the raw function behind a ``StageWorker`` method.
+
+    ``@ray.remote`` replaces the class with an actor-class descriptor whose own
+    ``__init__`` constructs an actor, so the original methods are reached via
+    ``__ray_metadata__.modified_class``. Ray's tracing decorator then exposes each
+    underlying function as ``__wrapped__``.
+    """
+    cls: Any = sw_module.StageWorker.__ray_metadata__.modified_class  # type: ignore[attr-defined]
+    method = getattr(cls, name)
+    return getattr(method, "__wrapped__", method)
+
+
+@pytest.fixture
+def worker() -> MagicMock:
+    """A mock self whose ``__init__`` has run for real, so its threads are real threads.
+
+    The loop targets resolve to ``MagicMock`` attributes, so each thread returns
+    immediately; only the thread objects themselves are under test. ``atexit.register`` is
+    patched out so the hook is observable and does not outlive the test.
+    """
+    mock_self = MagicMock(name="stage_worker")
+    with mock.patch.object(sw_module.atexit, "register") as register:
+        _get_impl("__init__")(mock_self, MagicMock(), MagicMock(), "test_stage", MagicMock())
+    mock_self.atexit_register = register
+    for name in _THREAD_NAMES:
+        getattr(mock_self, name).join(timeout=_JOIN_TIMEOUT_S)
+    return mock_self
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+@pytest.mark.parametrize("thread_name", _THREAD_NAMES)
+def test_worker_loop_threads_are_daemon(worker: MagicMock, thread_name: str) -> None:
+    """Daemon threads are the backstop that lets interpreter finalization complete."""
+    thread = getattr(worker, thread_name)
+    assert isinstance(thread, threading.Thread)
+    assert thread.daemon is True
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_init_registers_atexit_stop_hook(worker: MagicMock) -> None:
+    """``__init__`` registers the cooperative stop hook against the stop flag itself.
+
+    Registering the ``Event`` rather than the worker keeps the hook from pinning the actor
+    (and the user stage it holds) alive for the life of the process.
+    """
+    worker.atexit_register.assert_called_once_with(sw_module._signal_stop_at_exit, worker.stop_flag)
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_atexit_hook_sets_stop_flag() -> None:
+    """The hook breaks the loops rather than relying on the daemon flag alone."""
+    stop_flag = threading.Event()
+
+    sw_module._signal_stop_at_exit(stop_flag)
+
+    assert stop_flag.is_set()
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+def test_atexit_hook_never_raises() -> None:
+    """Interpreter teardown must not be perturbed by a failing hook."""
+    exploding = MagicMock()
+    exploding.set.side_effect = RuntimeError("interpreter is shutting down")
+
+    sw_module._signal_stop_at_exit(exploding)
+
+    exploding.set.assert_called_once()
+
+
+@pytest.mark.L1
+@pytest.mark.CPU
+@pytest.mark.parametrize("loop_name", ["_downloader_loop", "_deserializer_loop"])
+def test_loops_exit_when_stop_flag_is_set(loop_name: str) -> None:
+    """Setting ``stop_flag`` is sufficient to end a running loop."""
+    mock_self = MagicMock(name="stage_worker")
+    mock_self.stop_flag = threading.Event()
+
+    thread = threading.Thread(target=_get_impl(loop_name), args=(mock_self,), daemon=True)
+    thread.start()
+    mock_self.stop_flag.set()
+    thread.join(timeout=_JOIN_TIMEOUT_S)
+
+    assert not thread.is_alive()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmos-xenna"
-version = "0.5.8"
+version = "0.5.9"
 description = "A framework for building and running distributed, AI-powered data pipelines using Ray"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -11,7 +11,7 @@ dependencies = [
     "jinja2",
     "loguru",
     "pulp",
-    "ray[default]>=2.56.0,<2.57.0",
+    "ray[default]>=2.57.0,<2.58.0",
     "tabulate",
     "obstore<0.9.0",  # 0.9.0 regression: delete() ignores store prefix from from_url()
     "portpicker>=1.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "jinja2",
     "loguru",
     "pulp",
-    "ray[default]>=2.57.0,<2.58.0",
+    "ray[default]>=2.56.0",
     "tabulate",
     "obstore<0.9.0",  # 0.9.0 regression: delete() ignores store prefix from from_url()
     "portpicker>=1.6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -289,7 +289,7 @@ wheels = [
 
 [[package]]
 name = "cosmos-xenna"
-version = "0.5.8"
+version = "0.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -350,7 +350,7 @@ requires-dist = [
     { name = "portpicker", specifier = ">=1.6.0" },
     { name = "pulp" },
     { name = "pynvml", marker = "extra == 'gpu'" },
-    { name = "ray", extras = ["default"], specifier = ">=2.56.0,<2.57.0" },
+    { name = "ray", extras = ["default"], specifier = ">=2.57.0,<2.58.0" },
     { name = "requests", marker = "extra == 'examples'", specifier = ">=2.32.3" },
     { name = "tabulate" },
     { name = "torch", marker = "extra == 'examples'", specifier = ">=2.13.0" },
@@ -1783,7 +1783,7 @@ wheels = [
 
 [[package]]
 name = "ray"
-version = "2.56.1"
+version = "2.57.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1796,15 +1796,15 @@ dependencies = [
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/d9/a17feef16a123f5d32d4c5fa7de853c59ba702f8404cf452a7ce20faca13/ray-2.56.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:44bc0000c5bfad85b2ff6e0ef91e95f901d1a2d2fdd72f94f08a046eb494cd61", size = 66346989, upload-time = "2026-07-17T21:28:39.4Z" },
-    { url = "https://files.pythonhosted.org/packages/05/19/c3b1bcccd09decaf2a2e3370041ae67070bb1a8638f2665d36edfbb0261d/ray-2.56.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:8fdd6b096215906cf1f9acdc7898c9d6140606f2d27245778b8385a9f19e6cb0", size = 73319289, upload-time = "2026-07-17T21:28:44.502Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/7f/577a61bf2c8eff26e942afe53a6b03f4dbf5b4f233b832c228417d0c954e/ray-2.56.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:e5d3173696831134c76bd09451dfe95c32d72c271253b0d6b09d2df9994aa660", size = 74194147, upload-time = "2026-07-17T21:28:50.567Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/58/fab4cf69ec9be22210a6634f9310acf0b40c1c5a0f65d380f8cd11aa661e/ray-2.56.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:93dedab658334af81877b6ed840c4e5f85e2e0b1b3641b20eaaee37cad835cc6", size = 66291122, upload-time = "2026-07-17T21:28:59.906Z" },
-    { url = "https://files.pythonhosted.org/packages/68/9b/622d4f77fc65e9e2ee1a9d2480a1bde4b244edf65eda1f0c488dc8818e57/ray-2.56.1-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:7fdc47de4e230f0db7c6c668a9e161f864dac548bd32230986e0b0c36e386eb5", size = 73253432, upload-time = "2026-07-17T21:29:05.445Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ab/649395a3b286c4be86cfe4e8072a746f4d6b6dc68d78396f462d8b94795e/ray-2.56.1-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:81f2db202cc31bc3f5c4acf9ef154d10f1f39ece602d9d2d3108875c49bf01c3", size = 74131273, upload-time = "2026-07-17T21:29:10.547Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/71/e921682f4027459f261a8db2a56a25760458e12c95359f1ce56d525a28d3/ray-2.56.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:76f6268a669c1d9910f1d7b73903de3ede9850ed94d3e28318d495559bd37d0e", size = 66300044, upload-time = "2026-07-17T21:29:15.61Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/94/066849822fdd1c7a9221f3e2f9130e2a5eda83f47efc685211fb178b5a58/ray-2.56.1-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:ea372c7f95b14f1f76f0bdd2abc9602c56e88bc30699d2228f78133e7749b2f1", size = 73243912, upload-time = "2026-07-17T21:29:20.98Z" },
-    { url = "https://files.pythonhosted.org/packages/63/ac/74597352f729f9f7d998a93c6dd1de5efca3e6a5750f720d04a42f22bb3e/ray-2.56.1-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:ae91fe578fadea38c13a208a0fec27e1ced238ccdf5fff95ef3e30ac3071dec9", size = 74099698, upload-time = "2026-07-17T21:29:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/29/95/1350323300f88673d8d53f825d482834daddab9614c600855dc1a0189b33/ray-2.57.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:8ef591575c531793feb7f77744c52c34509ff58b48b30d0a3bcb6a1666256b02", size = 66747412, upload-time = "2026-08-11T00:21:19.219Z" },
+    { url = "https://files.pythonhosted.org/packages/80/bf/63da261f0424039171745ae62f9804fb6e55b7aa61a50e886d2069e0d77f/ray-2.57.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:eeb1d1adb61bd1d8affdc5fb555af0494fed8fec53b83576d4c60f811e06be94", size = 76886725, upload-time = "2026-08-11T00:21:24.801Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/3f/a580c1a8d9574372f83d4b97cd11ae64fdfa1c099c4728ec5197470cf094/ray-2.57.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:595d088b1fd1add64654c6cebe203e25903787b650d35c4a3dc008d451e48a41", size = 77891434, upload-time = "2026-08-11T00:21:29.991Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/c0/f67121caa9685b10d207dec33cd29ab8eaf81338a989edbcb8a87a28271b/ray-2.57.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:21b67eddc751ba8c65deee8654075c2b42851104c936ce42ca7944c4b6ec4799", size = 66692716, upload-time = "2026-08-11T00:21:40.072Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6c/bd35db22279a8697fc6bfdfb62447bbb0d0f14243e57cb298cf8d80fec85/ray-2.57.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:5e2d9258f751676f7581dc0ad307c2d91290825442366128c9ed0ccd0f60b845", size = 76825638, upload-time = "2026-08-11T00:21:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/29/3022974371111b3641fbddb4cf9344cb514b7bb45ca5cf0806c5a427b087/ray-2.57.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:71aa1c52fe7800cd217b601bf9ff557c2a3ffe5fad5b00f6792da9a678b2c914", size = 77832409, upload-time = "2026-08-11T00:21:50.988Z" },
+    { url = "https://files.pythonhosted.org/packages/41/4c/a54c6e9ec0aed04d2234f4a0f4ed9f0a16fe3df8503d194589cfbb78d259/ray-2.57.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:798a1ee24e4ede39e900fcc935d86db5f080d27a74c57e3238a5004ba9171200", size = 66700561, upload-time = "2026-08-11T00:21:56.657Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7c/bd6f79a92ac056fb5eed558d07d294a028bc72493969d8f9a99dc2fb3701/ray-2.57.0-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:e248939296f0c8f46b3e73421555776094972b1dbc73d4802479b99177c2269e", size = 76816843, upload-time = "2026-08-11T00:22:02.399Z" },
+    { url = "https://files.pythonhosted.org/packages/37/8d/d5638e9d83a3574327af29afb5a49903cfd31d70c2a45599b6a6ccd6b37c/ray-2.57.0-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:02cb2b5fdf41246f6b9306c85247ee7131bfeee9d36a4edae54653e02ed7890c", size = 77797246, upload-time = "2026-08-11T00:22:08.316Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -350,7 +350,7 @@ requires-dist = [
     { name = "portpicker", specifier = ">=1.6.0" },
     { name = "pulp" },
     { name = "pynvml", marker = "extra == 'gpu'" },
-    { name = "ray", extras = ["default"], specifier = ">=2.57.0,<2.58.0" },
+    { name = "ray", extras = ["default"], specifier = ">=2.56.0" },
     { name = "requests", marker = "extra == 'examples'", specifier = ">=2.32.3" },
     { name = "tabulate" },
     { name = "torch", marker = "extra == 'examples'", specifier = ">=2.13.0" },


### PR DESCRIPTION
Fixes stage workers failing to exit under Ray 2.57 process group cleanup.

**What was happening**
- Ray 2.57 enables process_group_cleanup_enabled by default and kills workers by process group.
- Stage worker loops and the resource monitors ran on non-daemon threads that were never stopped, so interpreter shutdown blocked and cleanup waited on workers that could never exit. Pipelines stalled and actors were repeatedly recreated.

**Changes**
- Stage worker loop threads are now daemon threads, and the stop flag is set on interpreter exit.
- Resource monitors gained stop methods, called from pipeline monitor teardown.
- Actor pools are stopped on every exit path out of the pipeline runner.
- Ray range raised to >=2.57.0,<2.58.0, version bumped to 0.5.9.
