### PR TITLE
fix: derive P2P chunk paths and body limits from the download catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Latest
 
+## [0.5.10]
+
+### Changed
+
+- The Rust `DataPlane::new` is now fallible and `P2pServer::new` takes the node's validated chunk set. The Python API is unchanged.
+
+### Fixed
+
+- The P2P file-distribution server now resolves each chunk's destination, range, and size from the node's download catalog instead of the peer's query parameters, and rejects uncatalogued chunks. `destination`, `range_start`, and `range_end` are now ignored.
+- P2P chunk uploads must match the chunk's catalogued size exactly, rejecting oversized bodies with `413 Payload Too Large` and truncated ones with `400 Bad Request`.
+- Fixed an off-by-one in chunked download sizes. Byte ranges are end-exclusive, so chunk length no longer adds one.
+
 ## [0.5.9]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -81,13 +81,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -104,9 +104,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -200,9 +200,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -221,9 +221,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
@@ -233,9 +233,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -251,9 +251,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -400,7 +400,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -461,7 +461,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -470,7 +470,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -494,13 +494,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -520,9 +520,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "env_filter"
@@ -565,15 +565,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixed"
@@ -611,9 +611,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -636,15 +636,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -653,38 +653,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "good_lp"
-version = "1.15.2"
+version = "1.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745190412d5ff4a54335cd16229a475ad3fb8f5474a5c1358292d62932187ea7"
+checksum = "c4255eb1d65eea322f73a326038f2bcec19dae13ca50fa557da19b03274b4d56"
 dependencies = [
  "fnv",
  "microlp",
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -800,9 +800,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -820,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -851,18 +851,18 @@ checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -985,16 +985,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1005,15 +1006,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1057,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1093,11 +1094,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1106,14 +1108,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1128,7 +1140,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1143,7 +1155,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1162,7 +1174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1177,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1188,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1200,9 +1212,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -1221,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -1265,9 +1277,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "microlp"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458ed987196f802dc47c69d4c5afcd19002d6c1c5f8f75c76d129bcf2425057a"
+checksum = "a8f19803f918039a07f3c32b23716824d8f073543417bdac5b1b8619817e3674"
 dependencies = [
  "log",
  "sprs",
@@ -1312,7 +1324,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1329,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -1377,7 +1389,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -1442,15 +1454,15 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1472,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -1490,18 +1502,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "once_cell",
@@ -1514,18 +1526,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1533,26 +1545,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1579,7 +1591,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -1587,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -1602,7 +1614,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1624,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1740,14 +1752,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1757,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1889,7 +1901,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1898,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1924,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1961,9 +1973,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2013,7 +2025,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2038,9 +2050,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2048,29 +2060,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2164,9 +2176,9 @@ checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "sprs"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dca58a33be2188d4edc71534f8bafa826e787cc28ca1c47f31be3423f0d6e55"
+checksum = "70d5a5663aa9f18d287877b8a889ee6cc2314e3a3778193ccc580d048d7d4abc"
 dependencies = [
  "ndarray",
  "num-complex",
@@ -2198,6 +2210,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,7 +2237,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2247,11 +2270,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -2262,25 +2285,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2303,9 +2326,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2320,13 +2343,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2352,13 +2375,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2385,7 +2409,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -2429,7 +2453,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2503,9 +2527,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2555,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2568,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2578,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2588,22 +2612,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -2623,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2643,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2702,7 +2726,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2713,7 +2737,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2830,9 +2854,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "yoke"
@@ -2853,28 +2877,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2894,7 +2918,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2906,9 +2930,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2917,9 +2941,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2928,13 +2952,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ name = "_cosmos_xenna"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.29.0", features = ["abi3-py312", "uuid"] }
+pyo3 = { version = "0.29.2", features = ["abi3-py312", "uuid"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-uuid = { version = "1.23.5", features = ["v4", "serde"] }
-tokio = { version = "1.52.3", features = ["full", "rt-multi-thread"] }
+uuid = { version = "1.25.0", features = ["v4", "serde"] }
+tokio = { version = "1.53.1", features = ["full", "rt-multi-thread"] }
 axum = "0.7.9"
 # disable-features is set to avoid needing to download openssl
 reqwest = { version = "0.12.28", default-features = false, features = [
@@ -22,12 +22,12 @@ reqwest = { version = "0.12.28", default-features = false, features = [
 ] }
 thiserror = "1.0.69"
 env_logger = "0.11.11"
-log = "0.4.33"
+log = "0.4.34"
 crossbeam-channel = "0.5.16"
 tempfile = "3.27.0"
 object_store = { version = "0.14.1", features = ["aws"] }
 url = "2.5.8"
-futures = "0.3.32"
+futures = "0.3.34"
 retry = "2.2.0"
 tokio-retry = "0.3"
 portpicker = "0.1.1"

--- a/cosmos_xenna/file_distribution/_file_distribution.py
+++ b/cosmos_xenna/file_distribution/_file_distribution.py
@@ -212,8 +212,8 @@ def _create_download_catalog(
             chunks_by_object[obj.object_id].append(chunk_id)
         else:
             for chunk_range in chunk_ranges:
-                # Calculate the size of this specific byte range chunk
-                chunk_length = chunk_range.end - chunk_range.start + 1
+                # Byte ranges are end-exclusive, so the length is the plain difference.
+                chunk_length = chunk_range.end - chunk_range.start
                 chunk_id = uuid.uuid4()
                 chunks.append(
                     models._DownloadChunk(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmos-xenna"
-version = "0.5.9"
+version = "0.5.10"
 description = "A framework for building and running distributed, AI-powered data pipelines using Ray"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/file_distribution/data_plane.rs
+++ b/src/file_distribution/data_plane.rs
@@ -59,7 +59,7 @@ use crate::file_distribution::p2p_download::{
     DownloadError as P2pDownloadError, P2pDownloadTask, P2pDownloaderWorkerPool,
     TaskStatus as P2pTaskStatus,
 };
-use crate::file_distribution::p2p_server::{P2pServer, P2pServerError};
+use crate::file_distribution::p2p_server::{P2pServer, P2pServerError, ServableChunks};
 use crate::file_distribution::unpacker::{
     TaskStatus as UnpackerTaskStatus, UnpackerError, UnpackerPool, UnpackerTask,
 };
@@ -72,6 +72,7 @@ use log::{debug, warn};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -668,6 +669,9 @@ pub struct DataPlane {
     node_parallelism: usize,
     download_catalog: Option<DownloadCatalog>,
     object_store_by_profile: Option<ObjectStoreByProfile>,
+    /// Validated at construction and retained so `start_p2p_server` does not depend
+    /// on `download_catalog` still being present.
+    servable_chunks: Arc<ServableChunks>,
     p2p_server: Option<P2pServer>,
     object_store_retry_config: RetryConfig,
     p2p_retry_config: RetryConfig,
@@ -685,27 +689,35 @@ impl DataPlane {
         object_store_by_profile: ObjectStoreByProfile,
         object_store_retry_config: RetryConfig,
         p2p_retry_config: RetryConfig,
-    ) -> Self {
+    ) -> Result<Self, P2pServerError> {
         // Default to warn level.
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
-        Self {
+        // Reject a malformed catalog here, before any actor reports itself ready.
+        let servable_chunks = Arc::new(ServableChunks::from_catalog(&download_catalog)?);
+        Ok(Self {
             node_id: node_id.to_string(),
             is_test,
             node_parallelism,
             download_catalog: Some(download_catalog),
             object_store_by_profile: Some(object_store_by_profile),
+            servable_chunks,
             p2p_server: None,
             object_store_retry_config,
             p2p_retry_config,
             orchestrator: None,
-        }
+        })
     }
 
     pub fn start_p2p_server(&mut self, port: Option<u16>) -> Result<u16, P2pServerError> {
         let port = port
             .or_else(|| Some(portpicker::pick_unused_port().unwrap()))
             .unwrap();
-        self.p2p_server = Some(P2pServer::new(port, self.node_id.clone(), self.is_test)?);
+        self.p2p_server = Some(P2pServer::new(
+            port,
+            self.node_id.clone(),
+            Arc::clone(&self.servable_chunks),
+            self.is_test,
+        )?);
         Ok(port)
     }
 

--- a/src/file_distribution/p2p_server.rs
+++ b/src/file_distribution/p2p_server.rs
@@ -34,10 +34,15 @@
 //!   found, it checks the final destination path, allowing it to serve data that might already have been
 //!   assembled. This allows flexibility in serving data.
 //!
+//!   The chunk's destination and byte range are resolved from this node's own download catalog rather
+//!   than from the request, so a peer cannot steer the handler at a path outside the download job.
+//!
 //! - **Receiving Chunks:** The server can accept chunks from peers via a `POST` request. This is used
 //!   for seeding chunks across the network, where one node might push a chunk it has to another.
-//!   Received chunks are always written to a temporary directory.
+//!   Received chunks are always written to a temporary directory. Only chunks listed in this node's
+//!   download catalog are accepted, and the body must be exactly the size the catalog declares.
 use super::common::{get_temp_chunk_path, resolve_path};
+use super::models::DownloadCatalog;
 use axum::{
     Json, Router,
     body::Bytes,
@@ -50,6 +55,7 @@ use log::debug;
 use pyo3::{exceptions::PyRuntimeError, prelude::*};
 use serde::Deserialize;
 use serde_json::json;
+use std::collections::HashMap;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -82,6 +88,13 @@ pub enum P2pServerError {
 
     #[error("Server thread exited before signaling readiness")]
     StartupAborted,
+
+    #[error("Download catalog is invalid: chunk {chunk_id} has range start {start} > end {end}")]
+    InvalidCatalogRange {
+        chunk_id: Uuid,
+        start: u64,
+        end: u64,
+    },
 }
 
 impl From<P2pServerError> for PyErr {
@@ -147,29 +160,104 @@ impl StreamingBodyWithGuard {
     }
 }
 
+/// Authoritative, locally-derived facts about a chunk this node may serve.
+///
+/// Built from the node's `DownloadCatalog`, never from request input. The catalog
+/// already pins a chunk's destination, byte range, and size, so the server has no
+/// reason to trust a peer's claims about any of them.
+#[derive(Debug, Clone)]
+struct ServableChunk {
+    destination: PathBuf,
+    range: Option<std::ops::Range<u64>>,
+    size: u64,
+}
+
+/// The set of chunks a node may serve or accept, validated once at construction.
+///
+/// Building this is the only way to get a `P2pServer`, so a catalog defect is
+/// reported before any listener opens rather than as a per-request error.
+#[derive(Debug, Clone, Default)]
+pub struct ServableChunks(HashMap<Uuid, ServableChunk>);
+
+impl ServableChunks {
+    pub fn from_catalog(catalog: &DownloadCatalog) -> Result<Self, P2pServerError> {
+        catalog
+            .chunks
+            .iter()
+            .map(|(chunk_id, chunk)| {
+                let range = chunk.value.range.as_ref().map(|r| r.start..r.end);
+                // An inverted range is a defect in the catalog we were handed, not
+                // something a peer can cause or a retry can fix.
+                if let Some(range) = &range
+                    && range.start > range.end
+                {
+                    return Err(P2pServerError::InvalidCatalogRange {
+                        chunk_id: *chunk_id,
+                        start: range.start,
+                        end: range.end,
+                    });
+                }
+                Ok((
+                    *chunk_id,
+                    ServableChunk {
+                        destination: chunk.destination.clone(),
+                        range,
+                        size: chunk.size,
+                    },
+                ))
+            })
+            .collect::<Result<HashMap<_, _>, _>>()
+            .map(Self)
+    }
+
+    fn get(&self, chunk_id: &Uuid) -> Option<&ServableChunk> {
+        self.0.get(chunk_id)
+    }
+}
+
 #[derive(Clone)]
 struct ServerConfig {
     node_id: String,
     is_test: bool,
+    /// Chunks this node is permitted to serve, keyed by chunk id.
+    servable_chunks: Arc<ServableChunks>,
 }
 
 async fn health_check() -> impl IntoResponse {
     (StatusCode::OK, Json(json!({ "status": "healthy" })))
 }
 
+/// Query parameters accepted for wire compatibility with older peers.
+///
+/// All of these are redundant with the download catalog and are deliberately
+/// ignored; see `chunk`.
 #[derive(Deserialize)]
 struct ChunkParams {
-    destination: PathBuf,
+    #[allow(dead_code)]
+    destination: Option<PathBuf>,
+    #[allow(dead_code)]
     range_start: Option<u64>,
+    #[allow(dead_code)]
     range_end: Option<u64>,
 }
 
 async fn chunk(
     Path(chunk_id): Path<Uuid>,
-    Query(params): Query<ChunkParams>,
+    Query(_params): Query<ChunkParams>,
     axum::extract::State(config): axum::extract::State<Arc<ServerConfig>>,
 ) -> Result<Response, (StatusCode, String)> {
     debug!("Request received for chunk {}", chunk_id);
+
+    // The destination and byte range are taken from the local catalog, not from the
+    // request. A peer that asks for a chunk this node was never told to download gets
+    // nothing, so a caller cannot steer this handler at an arbitrary path.
+    let servable = config.servable_chunks.get(&chunk_id).ok_or_else(|| {
+        debug!("Chunk {} is not in this node's download catalog", chunk_id);
+        (
+            StatusCode::NOT_FOUND,
+            format!("Chunk {} not found", chunk_id),
+        )
+    })?;
 
     let temp_chunk_path = get_temp_chunk_path(chunk_id, &config.node_id, config.is_test);
     debug!(
@@ -201,20 +289,27 @@ async fn chunk(
     }
     debug!("Temporary chunk file not found");
 
-    let final_path = resolve_path(params.destination.clone(), &config.node_id, config.is_test);
+    let final_path = resolve_path(
+        servable.destination.clone(),
+        &config.node_id,
+        config.is_test,
+    );
     debug!(
         "Checking for final destination file {}",
         final_path.display()
     );
     if final_path.exists() {
         debug!("Final destination file found {}", final_path.display());
-        let content = if let (Some(start), Some(end)) = (params.range_start, params.range_end) {
+        let content = if let Some(ref range) = servable.range {
+            let (start, end) = (range.start, range.end);
             debug!("Reading file range from {} to {}", start, end);
+            // Unreachable: `P2pServer::new` rejects inverted catalog ranges at startup.
+            // Kept because the `end - start` below would underflow if that ever regressed.
             if start > end {
-                debug!("range_start cannot be greater than range_end");
+                debug!("catalog range start is greater than range end");
                 return Err((
-                    StatusCode::BAD_REQUEST,
-                    "range_start cannot be greater than range_end".to_string(),
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "catalog range start cannot be greater than range end".to_string(),
                 ));
             }
             let mut file = match tokio::fs::File::open(&final_path).await {
@@ -248,12 +343,6 @@ async fn chunk(
                 ));
             }
             buffer
-        } else if params.range_start.is_some() || params.range_end.is_some() {
-            debug!("Both range_start and range_end must be provided for a range request");
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "Both range_start and range_end must be provided for a range request".to_string(),
-            ));
         } else {
             debug!("Reading full file {}", final_path.display());
             match tokio::fs::read(&final_path).await {
@@ -287,6 +376,16 @@ async fn write_chunk(
     axum::extract::State(config): axum::extract::State<Arc<ServerConfig>>,
     body: axum::body::Body,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    // Only chunks this node was told to download may be seeded to it. This bounds both
+    // the set of writable paths and the accepted body size to what the catalog declares.
+    let servable = config.servable_chunks.get(&chunk_id).ok_or_else(|| {
+        debug!("Refusing write for chunk {} (not in catalog)", chunk_id);
+        (
+            StatusCode::NOT_FOUND,
+            format!("Chunk {} not found", chunk_id),
+        )
+    })?;
+
     let temp_chunk_path = get_temp_chunk_path(chunk_id, &config.node_id, config.is_test);
     debug!(
         "Writing chunk {} to {}",
@@ -304,16 +403,44 @@ async fn write_chunk(
         ));
     }
 
-    let body_bytes = match axum::body::to_bytes(body, usize::MAX).await {
+    // Cap the buffered body at the size the catalog declares for this chunk. An
+    // unbounded limit here lets any caller that can reach the port exhaust node memory.
+    let expected_size = usize::try_from(servable.size).map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Chunk {} size does not fit in memory", chunk_id),
+        )
+    })?;
+    let body_bytes = match axum::body::to_bytes(body, expected_size).await {
         Ok(bytes) => bytes,
         Err(e) => {
             debug!("Failed to read request body: {}", e);
             return Err((
-                StatusCode::BAD_REQUEST,
+                StatusCode::PAYLOAD_TOO_LARGE,
                 format!("Failed to read request body: {}", e),
             ));
         }
     };
+
+    // A short body would otherwise be written and then served to peers as if it were
+    // the whole chunk, since GET prefers the temporary file over the assembled one.
+    if body_bytes.len() != expected_size {
+        debug!(
+            "Refusing truncated write for chunk {}: got {} bytes, expected {}",
+            chunk_id,
+            body_bytes.len(),
+            expected_size
+        );
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Chunk {} must be exactly {} bytes, got {}",
+                chunk_id,
+                expected_size,
+                body_bytes.len()
+            ),
+        ));
+    }
 
     if let Err(e) = tokio::fs::write(&temp_chunk_path, &body_bytes).await {
         debug!(
@@ -384,11 +511,13 @@ impl P2pServer {
     }
 }
 
-#[pymethods]
 impl P2pServer {
-    #[new]
-    #[pyo3(signature = (port, node_id, is_test=false))]
-    pub fn new(port: u16, node_id: String, is_test: bool) -> Result<Self, P2pServerError> {
+    pub fn new(
+        port: u16,
+        node_id: String,
+        servable_chunks: Arc<ServableChunks>,
+        is_test: bool,
+    ) -> Result<Self, P2pServerError> {
         // Reset the counter to prevent accumulation from previous instances
         ACTIVE_UPLOADS.store(0, Ordering::Relaxed);
 
@@ -400,7 +529,11 @@ impl P2pServer {
         } else {
             SocketAddr::from(([0, 0, 0, 0], port))
         };
-        let server_config = Arc::new(ServerConfig { node_id, is_test });
+        let server_config = Arc::new(ServerConfig {
+            node_id,
+            is_test,
+            servable_chunks,
+        });
 
         // Signal readiness back to the caller once the TCP listener is bound.
         // This prevents a race where the server isn't yet accepting connections
@@ -460,5 +593,254 @@ impl Drop for P2pServer {
         if let Err(e) = self._shutdown_internal() {
             eprintln!("Error shutting down P2P server during drop: {}", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_distribution::models::{ByteRange, ChunkToDownload, ObjectAndRange};
+    use std::collections::HashMap;
+
+    fn catalog_with_chunk(chunk_id: Uuid, destination: PathBuf, size: u64) -> DownloadCatalog {
+        let mut chunks = HashMap::new();
+        chunks.insert(
+            chunk_id,
+            ChunkToDownload {
+                chunk_id,
+                parent_object_id: Uuid::new_v4(),
+                profile_name: None,
+                value: ObjectAndRange {
+                    object_uri: "s3://bucket/key".to_string(),
+                    range: None,
+                    crc32_checksum: None,
+                },
+                destination,
+                size,
+            },
+        );
+        DownloadCatalog {
+            objects: HashMap::new(),
+            chunks,
+            chunks_by_object: HashMap::new(),
+        }
+    }
+
+    fn start_server(node_id: &str, catalog: &DownloadCatalog) -> P2pServer {
+        let port = portpicker::pick_unused_port().unwrap();
+        let servable = Arc::new(ServableChunks::from_catalog(catalog).unwrap());
+        P2pServer::new(port, node_id.to_string(), servable, true).unwrap()
+    }
+
+    /// A chunk id that is not in the catalog must never cause a file read, no matter
+    /// what path the caller names. This is the arbitrary-file-read regression guard.
+    #[test]
+    fn unknown_chunk_id_does_not_read_caller_supplied_path() {
+        let node_id = format!("test-node-{}", Uuid::new_v4());
+        let secret_dir = tempfile::tempdir().unwrap();
+        let secret = secret_dir.path().join("secret.txt");
+        std::fs::write(&secret, b"topsecret").unwrap();
+
+        // Empty catalog: the node was never told to download anything.
+        let catalog = DownloadCatalog {
+            objects: HashMap::new(),
+            chunks: HashMap::new(),
+            chunks_by_object: HashMap::new(),
+        };
+        let server = start_server(&node_id, &catalog);
+
+        let url = format!("http://{}/chunk/{}", server.addr(), Uuid::new_v4());
+        let response = reqwest::blocking::Client::new()
+            .get(&url)
+            .query(&[("destination", secret.to_str().unwrap())])
+            .send()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response.text().unwrap();
+        assert!(
+            !body.contains("topsecret"),
+            "server leaked caller-supplied file contents: {body}"
+        );
+    }
+
+    /// For a chunk that *is* in the catalog, the destination comes from the catalog.
+    /// A malicious `destination` query parameter must be ignored, not honored.
+    #[test]
+    fn catalog_destination_wins_over_caller_supplied_destination() {
+        let node_id = format!("test-node-{}", Uuid::new_v4());
+        let chunk_id = Uuid::new_v4();
+
+        // In test mode `resolve_path` sandboxes under P2P_DOWNLOAD_TEST_DIR/<node_id>,
+        // so materialize the catalog file where the handler will look for it.
+        let catalog_destination = PathBuf::from("/artifacts/model.bin");
+        let resolved = resolve_path(catalog_destination.clone(), &node_id, true);
+        std::fs::create_dir_all(resolved.parent().unwrap()).unwrap();
+        std::fs::write(&resolved, b"legitimate-chunk").unwrap();
+
+        let secret_dir = tempfile::tempdir().unwrap();
+        let secret = secret_dir.path().join("secret.txt");
+        std::fs::write(&secret, b"topsecret").unwrap();
+
+        let catalog = catalog_with_chunk(chunk_id, catalog_destination, 16);
+        let server = start_server(&node_id, &catalog);
+
+        let url = format!("http://{}/chunk/{}", server.addr(), chunk_id);
+        let response = reqwest::blocking::Client::new()
+            .get(&url)
+            .query(&[("destination", secret.to_str().unwrap())])
+            .send()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.bytes().unwrap().as_ref(), b"legitimate-chunk");
+    }
+
+    /// Writes are restricted to catalog chunks, so an unknown id cannot be used to
+    /// buffer an unbounded body in memory.
+    #[test]
+    fn write_rejects_chunk_absent_from_catalog() {
+        let node_id = format!("test-node-{}", Uuid::new_v4());
+        let catalog = DownloadCatalog {
+            objects: HashMap::new(),
+            chunks: HashMap::new(),
+            chunks_by_object: HashMap::new(),
+        };
+        let server = start_server(&node_id, &catalog);
+
+        let url = format!("http://{}/chunk/{}", server.addr(), Uuid::new_v4());
+        let response = reqwest::blocking::Client::new()
+            .post(&url)
+            .body(vec![0u8; 1024])
+            .send()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// A body larger than the size the catalog declares for the chunk is refused
+    /// rather than buffered.
+    #[test]
+    fn write_rejects_body_larger_than_catalog_chunk_size() {
+        let node_id = format!("test-node-{}", Uuid::new_v4());
+        let chunk_id = Uuid::new_v4();
+        let declared_size = 64u64;
+        let catalog =
+            catalog_with_chunk(chunk_id, PathBuf::from("/artifacts/x.bin"), declared_size);
+        let server = start_server(&node_id, &catalog);
+
+        let url = format!("http://{}/chunk/{}", server.addr(), chunk_id);
+        let response = reqwest::blocking::Client::new()
+            .post(&url)
+            .body(vec![0u8; (declared_size as usize) * 100])
+            .send()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    /// A short body must not be written: GET prefers the temporary chunk file, so a
+    /// truncated write would be served to peers as though it were the whole chunk.
+    #[test]
+    fn write_rejects_truncated_body() {
+        let node_id = format!("test-node-{}", Uuid::new_v4());
+        let chunk_id = Uuid::new_v4();
+        let declared_size = 64u64;
+        let catalog =
+            catalog_with_chunk(chunk_id, PathBuf::from("/artifacts/x.bin"), declared_size);
+        let server = start_server(&node_id, &catalog);
+
+        let url = format!("http://{}/chunk/{}", server.addr(), chunk_id);
+        for short_len in [0usize, 1, declared_size as usize - 1] {
+            let response = reqwest::blocking::Client::new()
+                .post(&url)
+                .body(vec![0u8; short_len])
+                .send()
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "a {short_len}-byte body must be rejected"
+            );
+        }
+
+        // The temporary chunk file must not exist after the rejected writes.
+        let temp_path = get_temp_chunk_path(chunk_id, &node_id, true);
+        assert!(
+            !temp_path.exists(),
+            "a rejected write left a partial chunk at {}",
+            temp_path.display()
+        );
+    }
+
+    /// An exactly-sized body is still accepted.
+    #[test]
+    fn write_accepts_exactly_sized_body() {
+        let node_id = format!("test-node-{}", Uuid::new_v4());
+        let chunk_id = Uuid::new_v4();
+        let declared_size = 64u64;
+        let catalog =
+            catalog_with_chunk(chunk_id, PathBuf::from("/artifacts/x.bin"), declared_size);
+        let server = start_server(&node_id, &catalog);
+
+        let url = format!("http://{}/chunk/{}", server.addr(), chunk_id);
+        let response = reqwest::blocking::Client::new()
+            .post(&url)
+            .body(vec![7u8; declared_size as usize])
+            .send()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let temp_path = get_temp_chunk_path(chunk_id, &node_id, true);
+        assert_eq!(std::fs::read(&temp_path).unwrap(), vec![7u8; 64]);
+    }
+
+    /// An inverted catalog range is rejected up front, rather than surfacing as a
+    /// per-request error that no retry could resolve.
+    #[test]
+    fn building_servable_chunks_rejects_inverted_range() {
+        let chunk_id = Uuid::new_v4();
+        let mut catalog = catalog_with_chunk(chunk_id, PathBuf::from("/artifacts/x.bin"), 4);
+        catalog.chunks.get_mut(&chunk_id).unwrap().value.range =
+            Some(ByteRange { start: 9, end: 3 });
+
+        match ServableChunks::from_catalog(&catalog) {
+            Ok(_) => panic!("an inverted catalog range must be rejected"),
+            Err(P2pServerError::InvalidCatalogRange {
+                chunk_id: id,
+                start: 9,
+                end: 3,
+            }) => assert_eq!(id, chunk_id),
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    /// The range served comes from the catalog, so a caller cannot use range
+    /// parameters to pull arbitrary offsets out of a file.
+    #[test]
+    fn catalog_range_is_authoritative() {
+        let node_id = format!("test-node-{}", Uuid::new_v4());
+        let chunk_id = Uuid::new_v4();
+
+        let catalog_destination = PathBuf::from("/artifacts/ranged.bin");
+        let resolved = resolve_path(catalog_destination.clone(), &node_id, true);
+        std::fs::create_dir_all(resolved.parent().unwrap()).unwrap();
+        std::fs::write(&resolved, b"0123456789").unwrap();
+
+        let mut catalog = catalog_with_chunk(chunk_id, catalog_destination, 4);
+        catalog.chunks.get_mut(&chunk_id).unwrap().value.range =
+            Some(ByteRange { start: 2, end: 6 });
+        let server = start_server(&node_id, &catalog);
+
+        let url = format!("http://{}/chunk/{}", server.addr(), chunk_id);
+        let response = reqwest::blocking::Client::new()
+            .get(&url)
+            .query(&[("range_start", "0"), ("range_end", "10")])
+            .send()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        // Catalog range 2..6, not the caller's 0..10.
+        assert_eq!(response.bytes().unwrap().as_ref(), b"2345");
     }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -289,7 +289,7 @@ wheels = [
 
 [[package]]
 name = "cosmos-xenna"
-version = "0.5.9"
+version = "0.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
The P2P server took a chunk's destination path and byte range from the requesting
peer's query parameters. In non-test mode resolve_path() returns the supplied path
unchanged, so the GET handler's fallback to the final destination would read
whatever path the caller named.

Every node receives the same catalog, which already pins each chunk's destination,
range, and size, so the request parameters were redundant. Look-up the chunk id in
the catalog and use those values instead; a chunk id that isn't in the catalog is
now a 404. The destination, range_start, and range_end parameters are still
accepted for wire compatibility with older peers but no longer influence which
file is read.

The same lookup gates writes, so a peer can only seed chunks this node was actually
told to download. That also gives write_chunk a real upper bound: the body must now
match the size the catalog declares for the chunk exactly, replacing an unbounded
to_bytes() limit that let any caller reachable on the port exhaust node memory.
Oversized bodies get a 413. Truncated bodies get a 400 rather than being written,
because GET prefers the temporary chunk file over the assembled one, so a short
write would otherwise be served to peers as though it were the whole chunk.

Chunk ranges are validated when the DataPlane is constructed rather than when a
request arrives, so a malformed catalog fails at startup instead of per-request.
This makes DataPlane::new fallible and changes P2pServer::new's parameter type;
both are internal Rust surfaces and the Python API is unchanged.

Also fixes an off-by-one in the Python chunk length calculation, which added one to
an end-exclusive range. It shipped inert, but had to be corrected here: it made
every ranged chunk's declared size one byte larger than the range it described,
which the new exact-size write check would have rejected.

Adds regression tests covering catalog-vs-caller precedence for both the
destination and the range, rejection of unknown, oversized, and truncated writes,
acceptance of an exactly sized body, and startup rejection of an inverted catalog
range.

Releases 0.5.10.